### PR TITLE
Added `org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api` to `JavaxServletApiRule`

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -202,6 +202,7 @@ Each Capability's GA coordinates correspond to the GA coordinates of the Compone
   * [org.eclipse.angus:jakarta.mail](https://search.maven.org/artifact/org.eclipse.angus/jakarta.mail)
 * [jakarta.servlet:jakarta.servlet-api](https://search.maven.org/artifact/jakarta.servlet/jakarta.servlet-api) ([JakartaServletApiRule](src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaServletApiRule.java))
   * [org.apache.tomcat:tomcat-servlet-api](https://search.maven.org/artifact/org.apache.tomcat/tomcat-servlet-api)
+  * [org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api](https://search.maven.org/artifact/org.eclipse.jetty.toolchain/jetty-jakarta-servlet-api)
 * [jakarta.ws.rs:jakarta.ws.rs-api](https://search.maven.org/artifact/jakarta.ws.rs/jakarta.ws.rs-api) ([JakartaWsRsApiRule](src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaWsRsApiRule.java))
   * [org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_3.0_spec](https://search.maven.org/artifact/org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_3.0_spec)
 * [javassist:javassist](https://search.maven.org/artifact/javassist/javassist) ([JavaAssistRule](src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaAssistRule.java))

--- a/samples/sample-all-deactivated/build.gradle.kts
+++ b/samples/sample-all-deactivated/build.gradle.kts
@@ -85,6 +85,7 @@ dependencies {
     implementation("org.apache.tomcat:servlet-api:6.0.53")
     implementation("org.apache.tomcat:tomcat-annotations-api:9.0.1")
     implementation("org.apache.tomcat:tomcat-servlet-api:9.0.1")
+    implementation("org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:5.0.2")
     implementation("org.apache.velocity:velocity-engine-core:2.3")
     implementation("org.apache.velocity:velocity:1.7")
     implementation("org.codehaus.woodstox:stax2-api:4.2.1")

--- a/samples/sample-all-deactivated/build.out
+++ b/samples/sample-all-deactivated/build.out
@@ -80,6 +80,7 @@ compileClasspath - Compile classpath for source set 'main'.
 +--- org.apache.tomcat:servlet-api:6.0.53 FAILED
 +--- org.apache.tomcat:tomcat-annotations-api:9.0.1 FAILED
 +--- org.apache.tomcat:tomcat-servlet-api:9.0.1 FAILED
++--- org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:5.0.2 FAILED
 +--- org.apache.velocity:velocity-engine-core:2.3 FAILED
 +--- org.apache.velocity:velocity:1.7 FAILED
 +--- org.codehaus.woodstox:stax2-api:4.2.1 FAILED

--- a/samples/sample-all/build.gradle.kts
+++ b/samples/sample-all/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     implementation("org.apache.tomcat:servlet-api:6.0.53")
     implementation("org.apache.tomcat:tomcat-annotations-api:10.1.1")
     implementation("org.apache.tomcat:tomcat-servlet-api:10.1.1")
+    implementation("org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:5.0.2")
     implementation("org.apache.velocity:velocity-engine-core:2.3")
     implementation("org.apache.velocity:velocity:1.7")
     implementation("org.codehaus.woodstox:stax2-api:4.2.1")

--- a/samples/sample-all/build.out
+++ b/samples/sample-all/build.out
@@ -96,6 +96,7 @@ compileClasspath - Compile classpath for source set 'main'.
 +--- org.apache.tomcat:servlet-api:6.0.53
 +--- org.apache.tomcat:tomcat-annotations-api:10.1.1
 +--- org.apache.tomcat:tomcat-servlet-api:10.1.1
++--- org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:5.0.2 -> org.apache.tomcat:tomcat-servlet-api:10.1.1
 +--- org.apache.velocity:velocity-engine-core:2.3
 |    +--- org.apache.commons:commons-lang3:3.11
 |    \--- org.slf4j:slf4j-api:1.7.30

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaServletApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaServletApiRule.java
@@ -31,7 +31,8 @@ public abstract class JakartaServletApiRule implements ComponentMetadataRule {
     public static final String CAPABILITY = CAPABILITY_GROUP + ":" + CAPABILITY_NAME;
 
     public static final String[] MODULES = {
-            "org.apache.tomcat:tomcat-servlet-api"
+            "org.apache.tomcat:tomcat-servlet-api",
+            "org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api",
     };
 
     @Override


### PR DESCRIPTION
For that one I'm not really sure whether the behavior is the desired one.
The `org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api` dependency seems to be a bundle that contains both the `javax.servlet:servlet-api`, `jakarta.servlet:jakarta.servlet-api`, additional `module-info.java` and xml files.