### PR TITLE
add the servletapi:servletapi artifact to the JavaxServletApiRule

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -276,6 +276,7 @@ Each Capability's GA coordinates correspond to the GA coordinates of the Compone
   * [org.apache.tomcat:servlet-api](https://search.maven.org/artifact/org.apache.tomcat/servlet-api)
   * [org.apache.tomcat:tomcat-servlet-api](https://search.maven.org/artifact/org.apache.tomcat/tomcat-servlet-api)
   * [org.apache.tomcat.embed:tomcat-embed-core](https://search.maven.org/artifact/org.apache.tomcat.embed/tomcat-embed-core)
+  * [servletapi:servletapi](https://search.maven.org/artifact/servletapi/servletapi)
 * [javax.validation:validation-api](https://search.maven.org/artifact/javax.validation/validation-api) ([JavaxValidationApiRule](src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxValidationApiRule.java))
   * [jakarta.validation:jakarta.validation-api](https://search.maven.org/artifact/jakarta.validation/jakarta.validation-api)
 * [javax.websocket:javax.websocket-api](https://search.maven.org/artifact/javax.websocket/javax.websocket-api) ([JavaxWebsocketApiRule](src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxWebsocketApiRule.java))

--- a/samples/sample-all-deactivated/build.gradle.kts
+++ b/samples/sample-all-deactivated/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     implementation("javax.servlet:jsp-api:2.0")
     implementation("javax.servlet:jstl:1.2")
     implementation("javax.servlet:servlet-api:2.5")
+    implementation("servletapi:servletapi:2.4")
     implementation("javax.validation:validation-api:2.0.1.Final")
     implementation("javax.websocket:javax.websocket-api:1.1")
     implementation("javax.websocket:javax.websocket-client-api:1.1")

--- a/samples/sample-all-deactivated/build.out
+++ b/samples/sample-all-deactivated/build.out
@@ -62,6 +62,7 @@ compileClasspath - Compile classpath for source set 'main'.
 +--- javax.servlet:jsp-api:2.0 FAILED
 +--- javax.servlet:jstl:1.2 FAILED
 +--- javax.servlet:servlet-api:2.5 FAILED
++--- servletapi:servletapi:2.4 FAILED
 +--- javax.validation:validation-api:2.0.1.Final FAILED
 +--- javax.websocket:javax.websocket-api:1.1 FAILED
 +--- javax.websocket:javax.websocket-client-api:1.1 FAILED

--- a/samples/sample-all/build.gradle.kts
+++ b/samples/sample-all/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     implementation("javax.servlet:jsp-api:2.0")
     implementation("javax.servlet:jstl:1.2")
     implementation("javax.servlet:servlet-api:2.5")
+    implementation("servletapi:servletapi:2.4")
     implementation("javax.validation:validation-api:2.0.1.Final")
     implementation("javax.websocket:javax.websocket-api:1.1")
     implementation("javax.websocket:javax.websocket-client-api:1.0")

--- a/samples/sample-all/build.out
+++ b/samples/sample-all/build.out
@@ -74,6 +74,7 @@ compileClasspath - Compile classpath for source set 'main'.
 +--- javax.servlet:jsp-api:2.0 -> jakarta.servlet.jsp:jakarta.servlet.jsp-api:2.3.6
 +--- javax.servlet:jstl:1.2 -> jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:1.2.7
 +--- javax.servlet:servlet-api:2.5 -> org.apache.tomcat:servlet-api:6.0.53
++--- servletapi:servletapi:2.4 -> org.apache.tomcat:servlet-api:6.0.53
 +--- javax.validation:validation-api:2.0.1.Final
 +--- javax.websocket:javax.websocket-api:1.1 -> org.eclipse.jetty.toolchain:jetty-javax-websocket-api:1.1.2
 +--- javax.websocket:javax.websocket-client-api:1.0 -> org.eclipse.jetty.toolchain:jetty-javax-websocket-api:1.1.2

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxServletApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxServletApiRule.java
@@ -37,7 +37,8 @@ public abstract class JavaxServletApiRule implements ComponentMetadataRule {
             "jakarta.servlet:jakarta.servlet-api",
             "org.apache.tomcat:servlet-api",
             "org.apache.tomcat:tomcat-servlet-api",
-            "org.apache.tomcat.embed:tomcat-embed-core"
+            "org.apache.tomcat.embed:tomcat-embed-core",
+            "servletapi:servletapi"
     };
 
     @Override


### PR DESCRIPTION
This pull requests adds the `servletapi:servletapi` library towards the `JavaxServletApiRule`.