### PR TITLE
Always apply 'jvm-ecosystem' plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [New Rules] [#42](https://github.com/gradlex-org/java-ecosystem-capabilities/issues/42) com.intellij:annotations / org.jetbrains:annotations (Thanks [Boris Petrov](https://github.com/boris-petrov)!)
 * [New Rules] [#43](https://github.com/gradlex-org/java-ecosystem-capabilities/issues/43) com.zaxxer:HikariCP (Thanks [Boris Petrov](https://github.com/boris-petrov)!)
 * [Adjusted Rule] [#37](https://github.com/gradlex-org/java-ecosystem-capabilities/issues/37) servletapi:servletapi (Thanks [Kenny Moens](https://github.com/kmoens)!)
+* [New] [#47](https://github.com/gradlex-org/java-ecosystem-capabilities/issues/47) Apply 'jvm-ecosystem' plugin
 
 ## Version 1.1
 

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesPlugin.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesPlugin.java
@@ -116,6 +116,10 @@ public abstract class JavaEcosystemCapabilitiesPlugin implements Plugin<Extensio
 
         ComponentMetadataHandler components;
         if (projectOrSettings instanceof Project) {
+            if (GradleVersion.current().compareTo(MINIMUM_SUPPORTED_VERSION_SETTINGS) >= 0) {
+                // If available, make sure 'jvm-ecosystem' is applied which adds the schemas for the attributes this plugin relies on
+                ((Project) projectOrSettings).getPlugins().apply("jvm-ecosystem");
+            }
             components = ((Project) projectOrSettings).getDependencies().getComponents();
         } else if (projectOrSettings instanceof Settings) {
             if (GradleVersion.current().compareTo(MINIMUM_SUPPORTED_VERSION_SETTINGS) < 0) {


### PR DESCRIPTION
To make sure the rules work as expected in non-standard Java projects.

See: #46 