### PR TITLE
Add ComponentStatusRule

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,18 +1,16 @@
 name: Build Plugin
-on: [ push, pull_request ]
+on: [ push ]
 jobs:
   gradle-build:
     runs-on: ubuntu-latest
     steps:
       - name: git clone
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v4.1.1
       - name: Set up JDK
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v4.0.0
         with:
           distribution: temurin
           java-version: 11
-      - name: gradle build
-        id: gradle
-        uses: gradle/gradle-build-action@v2.4.2
-        with:
-          arguments: checkAllVersions
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2.11.1
+      - run: "./gradlew checkAllVersions"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-rc-2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesPlugin.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesPlugin.java
@@ -28,6 +28,7 @@ import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.util.GradleVersion;
+import org.gradlex.javaecosystem.capabilities.componentrules.ComponentStatusRule;
 import org.gradlex.javaecosystem.capabilities.componentrules.GuavaComponentRule;
 import org.gradlex.javaecosystem.capabilities.rules.AopallianceRule;
 import org.gradlex.javaecosystem.capabilities.rules.AsmRule;
@@ -214,6 +215,7 @@ public abstract class JavaEcosystemCapabilitiesPlugin implements Plugin<Extensio
 
     private void registerComponentRules(ComponentMetadataHandler components) {
         components.withModule(GuavaComponentRule.MODULE, GuavaComponentRule.class);
+        components.all(ComponentStatusRule.class);
     }
 
     private void registerRule(

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/componentrules/ComponentStatusRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/componentrules/ComponentStatusRule.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 the GradleX team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradlex.javaecosystem.capabilities.componentrules;
+
+import org.gradle.api.artifacts.CacheableRule;
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ComponentMetadataRule;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Sets status of component versions that are not final releases to 'integration' instead of 'release'.
+ * Otherwise, they are considered when asking for the 'latest.release' version.
+ * POM metadata does not support the 'status' concept and thus Gradle assumes everything is a 'release' by default.
+ */
+@CacheableRule
+public abstract class ComponentStatusRule implements ComponentMetadataRule {
+
+    public static List<String> INTEGRATION_VERSION_MARKER = Arrays.asList(
+            "-b",
+            "alpha",
+            "beta",
+            "cr",
+            "m",
+            "rc"
+    );
+
+    @Override
+    public void execute(ComponentMetadataContext context) {
+        String version = context.getDetails().getId().getVersion().toLowerCase();
+        if (INTEGRATION_VERSION_MARKER.stream().anyMatch(version::contains)) {
+            context.getDetails().setStatus("integration");
+        }
+    }
+}

--- a/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/ComponentStatusRuleTest.groovy
+++ b/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/ComponentStatusRuleTest.groovy
@@ -1,0 +1,66 @@
+package org.gradlex.javaecosystem.capabilities.test
+
+import org.gradlex.javaecosystem.capabilities.test.fixture.GradleBuild
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+
+@IgnoreIf({ GradleBuild.GRADLE6_TEST || GradleBuild.GRADLE7_TEST })
+class ComponentStatusRuleTest extends Specification {
+
+    @Delegate
+    GradleBuild build = new GradleBuild()
+
+    def setup() {
+        buildFile << """
+            plugins {
+                id("org.gradlex.java-ecosystem-capabilities")
+                id("java-library")
+            }
+            repositories.mavenCentral()
+        """
+    }
+
+    def "status of non-released versions is set to integration"() {
+        given:
+        buildFile << """
+            dependencies {
+                implementation("com.sun.activation:jakarta.activation:2.0.0-rc1")
+                implementation("com.sun.mail:jakarta.mail:2.0.0-RC6")
+                implementation("jakarta.servlet:jakarta.servlet-api:5.0.0-M2")
+                implementation("org.jboss.resteasy:resteasy-client:5.0.0.Beta3")
+                implementation("org.slf4j:slf4j-api:2.0.0-alpha1")
+            }
+        """
+
+        expect:
+        status('com.sun.activation:jakarta.activation') == 'integration'
+        status('com.sun.mail:jakarta.mail') == 'integration'
+        status('jakarta.servlet:jakarta.servlet-api') == 'integration'
+        status('org.jboss.resteasy:resteasy-client') == 'integration'
+        status('org.slf4j:slf4j-api') == 'integration'
+    }
+
+    def "status of released versions stays release"() {
+        given:
+        buildFile << """
+            dependencies {
+                implementation("com.sun.activation:jakarta.activation:2.0.0")
+                implementation("com.sun.mail:jakarta.mail:2.0.0")
+                implementation("jakarta.servlet:jakarta.servlet-api:5.0.0")
+                implementation("org.jboss.resteasy:resteasy-client:5.0.0.Final")
+                implementation("org.slf4j:slf4j-api:2.0.0")
+            }
+        """
+
+        expect:
+        status('com.sun.activation:jakarta.activation') == 'release'
+        status('com.sun.mail:jakarta.mail') == 'release'
+        status('jakarta.servlet:jakarta.servlet-api') == 'release'
+        status('org.jboss.resteasy:resteasy-client') == 'release'
+        status('org.slf4j:slf4j-api') == 'release'
+    }
+
+    private String status(String module) {
+        dependencyInsight(module).output.readLines().find { it.contains('org.gradle.status') }.split('\\|')[2].trim()
+    }
+}

--- a/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/GuavaCapabilityConflictResolutionTest.groovy
+++ b/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/GuavaCapabilityConflictResolutionTest.groovy
@@ -4,6 +4,8 @@ import org.gradlex.javaecosystem.capabilities.test.fixture.GradleBuild
 import spock.lang.Specification
 import spock.lang.Tag
 
+import static org.gradlex.javaecosystem.capabilities.test.fixture.GradleBuild.GRADLE6_TEST
+
 class GuavaCapabilityConflictResolutionTest extends Specification {
 
     @Delegate
@@ -21,7 +23,7 @@ class GuavaCapabilityConflictResolutionTest extends Specification {
 
     def "resolves capability conflicts to Guava (standard-jvm)"() {
         given:
-        def attributeSetup = noJvmTargetEnvAttribute? 'configurations.compileClasspath { attributes.attribute(Attribute.of("org.gradle.jvm.environment", String::class.java), "standard-jvm") } ' : ''
+        def attributeSetup = GRADLE6_TEST? 'configurations.compileClasspath { attributes.attribute(Attribute.of("org.gradle.jvm.environment", String::class.java), "standard-jvm") } ' : ''
         buildFile << """
             plugins {
                 id("org.gradlex.java-ecosystem-capabilities")

--- a/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/GuavaClasspathTest.groovy
+++ b/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/GuavaClasspathTest.groovy
@@ -4,6 +4,8 @@ import org.gradlex.javaecosystem.capabilities.test.fixture.GradleBuild
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import static org.gradlex.javaecosystem.capabilities.test.fixture.GradleBuild.GRADLE6_TEST
+
 class GuavaClasspathTest extends Specification {
 
     @Delegate
@@ -120,8 +122,8 @@ class GuavaClasspathTest extends Specification {
     @Unroll
     def "has correct classpath for Guava selected by target environment version #guavaVersion-#versionSuffix, #jvmEnv, #classpath"() {
         given:
-        def attr = noJvmTargetEnvAttribute? 'Attribute.of("org.gradle.jvm.environment", String::class.java)' : 'org.gradle.api.attributes.java.TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE'
-        def attrValue = noJvmTargetEnvAttribute? "\"$jvmEnv\"" : "objects.named(\"$jvmEnv\")"
+        def attr = GRADLE6_TEST? 'Attribute.of("org.gradle.jvm.environment", String::class.java)' : 'org.gradle.api.attributes.java.TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE'
+        def attrValue = GRADLE6_TEST? "\"$jvmEnv\"" : "objects.named(\"$jvmEnv\")"
         buildFile << """
             plugins {
                 id("java-library")

--- a/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/fixture/GradleBuild.groovy
+++ b/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/fixture/GradleBuild.groovy
@@ -13,8 +13,9 @@ class GradleBuild {
     final File buildFile
     final File propertiesFile
 
-    final String gradleVersionUnderTest = System.getProperty("gradleVersionUnderTest")
-    final boolean noJvmTargetEnvAttribute = gradleVersionUnderTest?.startsWith("6.")
+    final static String GRADLE_VERSION_UNDER_TEST = System.getProperty("gradleVersionUnderTest")
+    final static boolean GRADLE6_TEST = GRADLE_VERSION_UNDER_TEST?.startsWith("6.")
+    final static boolean GRADLE7_TEST = GRADLE_VERSION_UNDER_TEST?.startsWith("7.")
 
     GradleBuild(File projectDir = Files.createTempDirectory("gradle-build").toFile()) {
         this.projectDir = projectDir
@@ -50,7 +51,11 @@ class GradleBuild {
     }
 
     BuildResult dependencies() {
-        runner('dependencies', "--configuration=compileClasspath").build()
+        runner('dependencies', '--configuration=compileClasspath').build()
+    }
+
+    BuildResult dependencyInsight(String module) {
+        runner('dependencyInsight', '--configuration=compileClasspath', '--dependency', module).build()
     }
 
     GradleRunner runner(String... args) {
@@ -60,7 +65,7 @@ class GradleBuild {
                 .withProjectDir(projectDir)
                 .withArguments(Arrays.asList(args) + '-s' + '-q')
                 .withDebug(ManagementFactory.getRuntimeMXBean().getInputArguments().toString().contains("-agentlib:jdwp")).with {
-            gradleVersionUnderTest ? it.withGradleVersion(gradleVersionUnderTest) : it
+            GRADLE_VERSION_UNDER_TEST ? it.withGradleVersion(GRADLE_VERSION_UNDER_TEST) : it
         }
     }
 }


### PR DESCRIPTION
Sets status of component versions that are not final releases to 'integration' instead of 'release'. Otherwise, they are considered when asking for the 'latest.release' version.