### PR TITLE
Merge with 'dev.jacomet.logging-capabilities' plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Java Ecosystem Capabilities Gradle plugin - Changelog
 
+## Version 2.0
+* [New Rules] [78](https://github.com/gradlex-org/java-ecosystem-capabilities/issues/78) Merge with ['dev.jacomet.logging-capabilities' plugin](https://github.com/ljacomet/logging-capabilities)
+
+### Breaking changes
+
+* Minimum required Gradle version raised to 6.6.2
+
 ## Version 1.5.2
 * [Adjusted Rule] [67](https://github.com/gradlex-org/java-ecosystem-capabilities/issues/67) Remove 'stax2-api' from StaxApiRule
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "org.gradlex"
-version = "1.5.2"
+version = "2.0"
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(11)) // to run tests that use Android with 11

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,23 @@ pluginPublishConventions {
         name.set("Jendrik Johannes")
         email.set("jendrik@gradlex.org")
     }
+    developer {
+        id.set("ljacomet")
+        name.set("Louis Jacomet")
+        email.set("louis@gradlex.org")
+    }
+}
+
+gradlePlugin {
+    plugins {
+        create("logging-capabilities") {
+            id = "org.gradlex.logging-capabilities"
+            implementationClass = "org.gradlex.javaecosystem.capabilities.LoggingCapabilitiesPlugin"
+            displayName = "Java Logging Capabilities"
+            description = "Adds configuration options for resolving logging framework conflicts."
+            tags = listOf("dependency", "dependencies", "dependency-management", "logging", "slf4j", "log4j2")
+        }
+    }
 }
 
 dependencies {
@@ -56,7 +73,7 @@ val checkAllVersions = tasks.register("checkAllVersions") {
     dependsOn(tasks.check)
 }
 
-listOf("6.2.2", "6.9.4", "7.0.2", "7.6.4", "8.0.2").forEach { gradleVersionUnderTest ->
+listOf("6.6.1", "6.9.4", "7.0.2", "7.6.4", "8.0.2").forEach { gradleVersionUnderTest ->
     val testGradle = tasks.register<Test>("testGradle$gradleVersionUnderTest") {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
         description = "Runs tests against Gradle $gradleVersionUnderTest"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ val checkAllVersions = tasks.register("checkAllVersions") {
     dependsOn(tasks.check)
 }
 
-listOf("6.0.1", "6.4.1", "6.9.3", "7.0.2", "7.1.1", "7.2", "7.3.3", "7.4.2", "7.5.1", "7.6.1").forEach { gradleVersionUnderTest ->
+listOf("6.2.2", "6.9.4", "7.0.2", "7.6.4", "8.0.2").forEach { gradleVersionUnderTest ->
     val testGradle = tasks.register<Test>("testGradle$gradleVersionUnderTest") {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
         description = "Runs tests against Gradle $gradleVersionUnderTest"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,10 @@ gradlePlugin {
             description = "Adds configuration options for resolving logging framework conflicts."
             tags = listOf("dependency", "dependencies", "dependency-management", "logging", "slf4j", "log4j2")
         }
+        create("java-ecosystem-capabilities-base") {
+            id = "org.gradlex.java-ecosystem-capabilities-base"
+            implementationClass = "org.gradlex.javaecosystem.capabilities.JavaEcosystemCapabilitiesBasePlugin"
+       }
     }
 }
 

--- a/gradle/checkstyle/header.txt
+++ b/gradle/checkstyle/header.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesBasePlugin.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesBasePlugin.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright the GradleX team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.gradlex.javaecosystem.capabilities;
 
 import org.gradle.api.NonNullApi;

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesBasePlugin.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesBasePlugin.java
@@ -22,6 +22,8 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.ComponentMetadataRule;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.initialization.Settings;
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.util.GradleVersion;
 import org.gradlex.javaecosystem.capabilities.componentrules.GuavaComponentRule;
@@ -103,6 +105,11 @@ public class JavaEcosystemCapabilitiesBasePlugin implements Plugin<ExtensionAwar
     // Minimal version that works reliably with alignment and has the substitution rules `using` API
     private static final GradleVersion MINIMUM_SUPPORTED_VERSION = GradleVersion.version("6.6.1");
     private static final GradleVersion MINIMUM_SUPPORTED_VERSION_SETTINGS = GradleVersion.version("6.8");
+
+    static boolean basePluginNotYetRegisteredInSettings(Project project) {
+        SettingsInternal settings = ((GradleInternal) project.getGradle()).getSettings();
+        return null == settings.getPlugins().findPlugin(JavaEcosystemCapabilitiesBasePlugin.class);
+    }
 
     @Override
     public void apply(ExtensionAware projectOrSettings) {

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesBasePlugin.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesBasePlugin.java
@@ -101,7 +101,7 @@ import org.gradlex.javaecosystem.capabilities.rules.logging.Slf4JvsLog4J2ForLog4
 public class JavaEcosystemCapabilitiesBasePlugin implements Plugin<ExtensionAware> {
 
     // Minimal version that works reliably with alignment
-    private static final GradleVersion MINIMUM_SUPPORTED_VERSION = GradleVersion.version("6.2");
+    private static final GradleVersion MINIMUM_SUPPORTED_VERSION = GradleVersion.version("6.2.2");
     private static final GradleVersion MINIMUM_SUPPORTED_VERSION_SETTINGS = GradleVersion.version("6.8");
 
     @Override

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesBasePlugin.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesBasePlugin.java
@@ -100,8 +100,8 @@ import org.gradlex.javaecosystem.capabilities.rules.logging.Slf4JvsLog4J2ForLog4
 @NonNullApi
 public class JavaEcosystemCapabilitiesBasePlugin implements Plugin<ExtensionAware> {
 
-    // Minimal version that works reliably with alignment
-    private static final GradleVersion MINIMUM_SUPPORTED_VERSION = GradleVersion.version("6.2.2");
+    // Minimal version that works reliably with alignment and has the substitution rules `using` API
+    private static final GradleVersion MINIMUM_SUPPORTED_VERSION = GradleVersion.version("6.6.1");
     private static final GradleVersion MINIMUM_SUPPORTED_VERSION_SETTINGS = GradleVersion.version("6.8");
 
     @Override

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesBasePlugin.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesBasePlugin.java
@@ -1,0 +1,184 @@
+package org.gradlex.javaecosystem.capabilities;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ComponentMetadataRule;
+import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.util.GradleVersion;
+import org.gradlex.javaecosystem.capabilities.componentrules.GuavaComponentRule;
+import org.gradlex.javaecosystem.capabilities.rules.AopallianceRule;
+import org.gradlex.javaecosystem.capabilities.rules.AsmRule;
+import org.gradlex.javaecosystem.capabilities.rules.BouncycastleBcmailRule;
+import org.gradlex.javaecosystem.capabilities.rules.BouncycastleBcpgRule;
+import org.gradlex.javaecosystem.capabilities.rules.BouncycastleBcpkixRule;
+import org.gradlex.javaecosystem.capabilities.rules.BouncycastleBcprovRule;
+import org.gradlex.javaecosystem.capabilities.rules.BouncycastleBctlsRule;
+import org.gradlex.javaecosystem.capabilities.rules.BouncycastleBctspRule;
+import org.gradlex.javaecosystem.capabilities.rules.BouncycastleBcutilRule;
+import org.gradlex.javaecosystem.capabilities.rules.C3p0Rule;
+import org.gradlex.javaecosystem.capabilities.rules.CGlibRule;
+import org.gradlex.javaecosystem.capabilities.rules.CommonsIoRule;
+import org.gradlex.javaecosystem.capabilities.rules.Dom4jRule;
+import org.gradlex.javaecosystem.capabilities.rules.FindbugsAnnotationsRule;
+import org.gradlex.javaecosystem.capabilities.rules.GoogleCollectionsRule;
+import org.gradlex.javaecosystem.capabilities.rules.GuavaListenableFutureRule;
+import org.gradlex.javaecosystem.capabilities.rules.GuavaRule;
+import org.gradlex.javaecosystem.capabilities.rules.HamcrestCoreRule;
+import org.gradlex.javaecosystem.capabilities.rules.HamcrestLibraryRule;
+import org.gradlex.javaecosystem.capabilities.rules.HikariCPRule;
+import org.gradlex.javaecosystem.capabilities.rules.IntellijAnnotationsRule;
+import org.gradlex.javaecosystem.capabilities.rules.JakartaActivationApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JakartaActivationImplementationRule;
+import org.gradlex.javaecosystem.capabilities.rules.JakartaAnnotationApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JakartaJsonApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JakartaMailApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JakartaServletApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JakartaWebsocketApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JakartaWebsocketClientApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JakartaWsRsApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaAssistRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxActivationApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxAnnotationApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxEjbApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxElApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxInjectApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxJsonApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxJwsApisRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxMailApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxPersistenceApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxServletApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxServletJspRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxServletJstlRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxSoapApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxValidationApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxWebsocketApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxWsRsApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxXmlBindApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JavaxXmlWsApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.JcipAnnotationsRule;
+import org.gradlex.javaecosystem.capabilities.rules.JnaPlatformRule;
+import org.gradlex.javaecosystem.capabilities.rules.JtsCoreRule;
+import org.gradlex.javaecosystem.capabilities.rules.JtsRule;
+import org.gradlex.javaecosystem.capabilities.rules.JunitRule;
+import org.gradlex.javaecosystem.capabilities.rules.PostgresqlRule;
+import org.gradlex.javaecosystem.capabilities.rules.StaxApiRule;
+import org.gradlex.javaecosystem.capabilities.rules.VelocityRule;
+import org.gradlex.javaecosystem.capabilities.rules.WoodstoxAslRule;
+
+import java.util.Set;
+
+public class JavaEcosystemCapabilitiesBasePlugin implements Plugin<ExtensionAware> {
+
+    private static final GradleVersion MINIMUM_SUPPORTED_VERSION = GradleVersion.version("6.0");
+    private static final GradleVersion MINIMUM_SUPPORTED_VERSION_SETTINGS = GradleVersion.version("6.8");
+
+    @Override
+    public void apply(ExtensionAware projectOrSettings) {
+        if (GradleVersion.current().compareTo(MINIMUM_SUPPORTED_VERSION) < 0) {
+            throw new IllegalStateException("Plugin requires at least Gradle " + MINIMUM_SUPPORTED_VERSION.getVersion());
+        }
+
+        ComponentMetadataHandler components;
+        if (projectOrSettings instanceof Project) {
+            if (GradleVersion.current().compareTo(MINIMUM_SUPPORTED_VERSION_SETTINGS) >= 0) {
+                // If available, make sure 'jvm-ecosystem' is applied which adds the schemas for the attributes this plugin relies on
+                ((Project) projectOrSettings).getPlugins().apply("jvm-ecosystem");
+            }
+            components = ((Project) projectOrSettings).getDependencies().getComponents();
+        } else if (projectOrSettings instanceof Settings) {
+            if (GradleVersion.current().compareTo(MINIMUM_SUPPORTED_VERSION_SETTINGS) < 0) {
+                throw new IllegalStateException("Using this plugin in settings.gradle requires at least Gradle " + MINIMUM_SUPPORTED_VERSION_SETTINGS.getVersion());
+            }
+            //noinspection UnstableApiUsage
+            components = ((Settings) projectOrSettings).getDependencyResolutionManagement().getComponents();
+        } else {
+            throw new IllegalStateException("Cannot apply plugin to: " + projectOrSettings.getClass().getName());
+        }
+        registerCapabilityRules(components);
+    }
+
+
+    private void registerCapabilityRules(ComponentMetadataHandler components) {
+        registerRule(AopallianceRule.MODULES, AopallianceRule.class, components);
+        registerRule(AsmRule.MODULES, AsmRule.class, components);
+        registerRule(BouncycastleBcmailRule.MODULES, BouncycastleBcmailRule.class, components);
+        registerRule(BouncycastleBcpgRule.MODULES, BouncycastleBcpgRule.class, components);
+        registerRule(BouncycastleBcpkixRule.MODULES, BouncycastleBcpkixRule.class, components);
+        registerRule(BouncycastleBcprovRule.MODULES, BouncycastleBcprovRule.class, components);
+        registerRule(BouncycastleBctlsRule.MODULES, BouncycastleBctlsRule.class, components);
+        registerRule(BouncycastleBctspRule.MODULES, BouncycastleBctspRule.class, components);
+        registerRule(BouncycastleBcutilRule.MODULES, BouncycastleBcutilRule.class, components);
+        registerRule(C3p0Rule.MODULES, C3p0Rule.class, components);
+        registerRule(CGlibRule.MODULES, CGlibRule.class, components);
+        registerRule(CommonsIoRule.MODULES, CommonsIoRule.class, components);
+        registerRule(Dom4jRule.MODULES, Dom4jRule.class, components);
+        registerRule(FindbugsAnnotationsRule.MODULES, FindbugsAnnotationsRule.class, components);
+        registerRule(GoogleCollectionsRule.MODULES, GoogleCollectionsRule.class, components);
+        registerRule(GuavaListenableFutureRule.MODULES, GuavaListenableFutureRule.class, components);
+        registerRule(GuavaRule.MODULES, GuavaRule.class, components);
+        registerRule(HamcrestCoreRule.MODULES, HamcrestCoreRule.class, components);
+        registerRule(HamcrestLibraryRule.MODULES, HamcrestLibraryRule.class, components);
+        registerRule(HikariCPRule.MODULES, HikariCPRule.class, components);
+        registerRule(IntellijAnnotationsRule.MODULES, IntellijAnnotationsRule.class, components);
+
+        registerRule(JakartaActivationApiRule.MODULES, JakartaActivationApiRule.class, components);
+        registerRule(JakartaActivationImplementationRule.MODULES, JakartaActivationImplementationRule.class, components);
+        registerRule(JakartaAnnotationApiRule.MODULES, JakartaAnnotationApiRule.class, components);
+        registerRule(JakartaJsonApiRule.MODULES, JakartaJsonApiRule.class, components);
+        registerRule(JakartaMailApiRule.MODULES, JakartaMailApiRule.class, components);
+        registerRule(JakartaServletApiRule.MODULES, JakartaServletApiRule.class, components);
+        registerRule(JakartaWebsocketApiRule.MODULES, JakartaWebsocketApiRule.class, components);
+        registerRule(JakartaWebsocketClientApiRule.MODULES, JakartaWebsocketClientApiRule.class, components);
+        registerRule(JakartaWsRsApiRule.MODULES, JakartaWsRsApiRule.class, components);
+
+        registerRule(JavaAssistRule.MODULES, JavaAssistRule.class, components);
+
+        registerRule(JavaxActivationApiRule.MODULES, JavaxActivationApiRule.class, components);
+        registerRule(JavaxAnnotationApiRule.MODULES, JavaxAnnotationApiRule.class, components);
+        registerRule(JavaxEjbApiRule.MODULES, JavaxEjbApiRule.class, components);
+        registerRule(JavaxElApiRule.MODULES, JavaxElApiRule.class, components);
+        registerRule(JavaxInjectApiRule.MODULES, JavaxInjectApiRule.class, components);
+        registerRule(JavaxJsonApiRule.MODULES, JavaxJsonApiRule.class, components);
+        registerRule(JavaxJwsApisRule.MODULES, JavaxJwsApisRule.class, components);
+        registerRule(JavaxMailApiRule.MODULES, JavaxMailApiRule.class, components);
+        registerRule(JavaxPersistenceApiRule.MODULES, JavaxPersistenceApiRule.class, components);
+        registerRule(JavaxServletApiRule.MODULES, JavaxServletApiRule.class, components);
+        registerRule(JavaxServletJspRule.MODULES, JavaxServletJspRule.class, components);
+        registerRule(JavaxServletJstlRule.MODULES, JavaxServletJstlRule.class, components);
+        registerRule(JavaxSoapApiRule.MODULES, JavaxSoapApiRule.class, components);
+        registerRule(JavaxValidationApiRule.MODULES, JavaxValidationApiRule.class, components);
+        registerRule(JavaxWebsocketApiRule.MODULES, JavaxWebsocketApiRule.class, components);
+        registerRule(JavaxWsRsApiRule.MODULES, JavaxWsRsApiRule.class, components);
+        registerRule(JavaxXmlBindApiRule.MODULES, JavaxXmlBindApiRule.class, components);
+        registerRule(JavaxXmlWsApiRule.MODULES, JavaxXmlWsApiRule.class, components);
+
+        registerRule(JcipAnnotationsRule.MODULES, JcipAnnotationsRule.class, components);
+        registerRule(JnaPlatformRule.MODULES, JnaPlatformRule.class, components);
+        registerRule(JtsCoreRule.MODULES, JtsCoreRule.class, components);
+        registerRule(JtsRule.MODULES, JtsRule.class, components);
+        registerRule(JunitRule.MODULES, JunitRule.class, components);
+        registerRule(PostgresqlRule.MODULES, PostgresqlRule.class, components);
+        registerRule(StaxApiRule.MODULES, StaxApiRule.class, components);
+        registerRule(VelocityRule.MODULES, VelocityRule.class, components);
+        registerRule(WoodstoxAslRule.MODULES, WoodstoxAslRule.class, components);
+
+        registerComponentRules(components);
+    }
+
+    private void registerComponentRules(ComponentMetadataHandler components) {
+        components.withModule(GuavaComponentRule.MODULE, GuavaComponentRule.class);
+    }
+
+    private void registerRule(
+            String[] modules,
+            Class<? extends ComponentMetadataRule> rule,
+            ComponentMetadataHandler components) {
+
+
+        for (String module : modules) {
+            components.withModule(module, rule);
+        }
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesExtension.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesPlugin.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesPlugin.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/JavaEcosystemCapabilitiesPlugin.java
@@ -93,7 +93,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
-@SuppressWarnings("unused")
 @NonNullApi
 public abstract class JavaEcosystemCapabilitiesPlugin implements Plugin<PluginAware> {
 

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/LoggingCapabilitiesExtension.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/LoggingCapabilitiesExtension.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright the GradleX team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradlex.javaecosystem.capabilities;
+
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.CapabilitiesResolution;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ExternalDependency;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradlex.javaecosystem.capabilities.actions.Slf4JEnforcementSubstitutionsUsing;
+import org.gradlex.javaecosystem.capabilities.rules.logging.CommonsLoggingImplementationRule;
+import org.gradlex.javaecosystem.capabilities.rules.logging.Log4J2Implementation;
+import org.gradlex.javaecosystem.capabilities.rules.logging.Log4J2vsSlf4J;
+import org.gradlex.javaecosystem.capabilities.rules.logging.LoggingModuleIdentifiers;
+import org.gradlex.javaecosystem.capabilities.rules.logging.Slf4JImplementation;
+import org.gradlex.javaecosystem.capabilities.rules.logging.Slf4JVsJCL;
+import org.gradlex.javaecosystem.capabilities.rules.logging.Slf4JVsLog4J2ForJCL;
+import org.gradlex.javaecosystem.capabilities.rules.logging.Slf4JvsJUL;
+import org.gradlex.javaecosystem.capabilities.rules.logging.Slf4JvsLog4J;
+import org.gradlex.javaecosystem.capabilities.rules.logging.Slf4JvsLog4J2ForJUL;
+import org.gradlex.javaecosystem.capabilities.rules.logging.Slf4JvsLog4J2ForLog4J;
+
+/**
+ * Project extension that enables expressing preference over potential logging capabilities conflicts.
+ */
+public class LoggingCapabilitiesExtension {
+    private final ConfigurationContainer configurations;
+    private final DependencyHandler dependencies;
+
+    public LoggingCapabilitiesExtension(ConfigurationContainer configurations, DependencyHandler dependencies) {
+        this.configurations = configurations;
+        this.dependencies = dependencies;
+    }
+
+    /**
+     * Selects the provided module as the Slf4J binding to use.
+     * <p>
+     * This also resolves all other potential conflicts with the passed in module in favor of it.
+     *
+     * @param dependencyNotation the Slf4J binding module as a dependency or {@code group:name:version} notation
+     */
+    public void selectSlf4JBinding(Object dependencyNotation) {
+        ExternalDependency dependency = validateNotation(dependencyNotation);
+        String because = "Logging capabilities plugin selected Slf4J binding";
+        if (LoggingModuleIdentifiers.SLF4J_LOG4J12.matches(dependency)) {
+            selectCapabilityConflict(Slf4JvsLog4J.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(Slf4JImplementation.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.SLF4J_JDK14.matches(dependency)) {
+            selectCapabilityConflict(Slf4JvsJUL.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(Slf4JImplementation.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.SLF4J_JCL.matches(dependency)) {
+            selectCapabilityConflict(Slf4JVsJCL.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(Slf4JImplementation.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.LOG4J_SLF4J_IMPL.matches(dependency) || LoggingModuleIdentifiers.LOG4J_SLF4J2_IMPL.matches(dependency)) {
+            selectCapabilityConflict(Log4J2vsSlf4J.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(Slf4JImplementation.CAPABILITY_ID, dependency, because);
+            // Slf4j binding towards log4j2, so we need to make sure Log4j-core is selected
+            selectCapabilityConflict(Log4J2Implementation.CAPABILITY_ID, validateNotation(LoggingModuleIdentifiers.LOG4J_CORE.moduleId), because);
+        } else if (LoggingModuleIdentifiers.LOGBACK_CLASSIC.matches(dependency) || LoggingModuleIdentifiers.SLF4J_SIMPLE.matches(dependency)) {
+            selectCapabilityConflict(Slf4JImplementation.CAPABILITY_ID, dependency, because);
+        } else {
+            throw new IllegalArgumentException("Provided dependency '" + dependency + "' is not a valid Slf4J binding");
+        }
+    }
+
+    /**
+     * Selects the provided module as the Slf4J binding to use for the resolution of the given configuration.
+     * <p>
+     * This also resolves all other potential conflicts with the passed in module in favor of it.
+     *
+     * @param configurationName  the configuration to be setup
+     * @param dependencyNotation the Slf4J binding module as a dependency or {@code group:name:version} notation
+     */
+    public void selectSlf4JBinding(String configurationName, Object dependencyNotation) {
+        ExternalDependency dependency = validateNotation(dependencyNotation);
+        String because = "Logging capabilities plugin selected Slf4J binding";
+        if (LoggingModuleIdentifiers.SLF4J_LOG4J12.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Slf4JvsLog4J.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(configurationName, Slf4JImplementation.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.SLF4J_JDK14.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Slf4JvsJUL.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(configurationName, Slf4JImplementation.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.SLF4J_JCL.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Slf4JVsJCL.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(configurationName, Slf4JImplementation.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.LOG4J_SLF4J_IMPL.matches(dependency) || LoggingModuleIdentifiers.LOG4J_SLF4J2_IMPL.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Log4J2vsSlf4J.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(configurationName, Slf4JImplementation.CAPABILITY_ID, dependency, because);
+            // Slf4j binding towards log4j2, so we need to make sure Log4j-core is selected
+            selectCapabilityConflict(configurationName, Log4J2Implementation.CAPABILITY_ID, validateNotation(LoggingModuleIdentifiers.LOG4J_CORE.moduleId), because);
+        } else if (LoggingModuleIdentifiers.LOGBACK_CLASSIC.matches(dependency) || LoggingModuleIdentifiers.SLF4J_SIMPLE.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Slf4JImplementation.CAPABILITY_ID, dependency, because);
+        } else {
+            throw new IllegalArgumentException("Provided dependency '" + dependency + "' is not a valid Slf4J binding");
+        }
+    }
+
+    /**
+     * Selects the provided module as the Log4J2 implementation to use.
+     * <p>
+     * This also resolves all other potential conflicts with the passed in module in favor of it.
+     *
+     * @param dependencyNotation the Log4J 2 implementation as a dependency or {@code group:name:version} notation
+     */
+    public void selectLog4J2Implementation(Object dependencyNotation) {
+        ExternalDependency dependency = validateNotation(dependencyNotation);
+        String because = "Logging capabilities plugin selected Log4J2 implementation";
+        if (LoggingModuleIdentifiers.LOG4J_CORE.matches(dependency)) {
+            selectCapabilityConflict(Log4J2Implementation.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.LOG4J_TO_SLF4J.matches(dependency)) {
+            selectCapabilityConflict(Log4J2Implementation.CAPABILITY_ID, dependency, because);
+        } else {
+            throw new IllegalArgumentException("Provided dependency '" + dependency + "' is not a valid Log4J2 implementation");
+        }
+    }
+
+    /**
+     * Selects the provided module as the Log4J2 implementation to use for the resolution of the given configuration.
+     * <p>
+     * This also resolves all other potential conflicts with the passed in module in favor of it.
+     *
+     * @param configurationName  the configuration to be setup
+     * @param dependencyNotation the Log4J 2 implementation as a dependency or {@code group:name:version} notation
+     */
+    public void selectLog4J2Implementation(String configurationName, Object dependencyNotation) {
+        ExternalDependency dependency = validateNotation(dependencyNotation);
+        String because = "Logging capabilities plugin selected Log4J2 implementation";
+        if (LoggingModuleIdentifiers.LOG4J_CORE.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Log4J2Implementation.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.LOG4J_TO_SLF4J.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Log4J2Implementation.CAPABILITY_ID, dependency, because);
+        } else {
+            throw new IllegalArgumentException("Provided dependency '" + dependency + "' is not a valid Log4J2 implementation");
+        }
+    }
+
+    /**
+     * Selects the provided module as the Log4J 1.2 implementation to use.
+     * <p>
+     * This also resolves all other potential conflicts with the passed in module in favor of it.
+     *
+     * @param dependencyNotation the Log4J 1.2 implementation module as a dependency or {@code group:name:version} notation
+     */
+    public void selectLog4J12Implementation(Object dependencyNotation) {
+        ExternalDependency dependency = validateNotation(dependencyNotation);
+        String because = "Logging capabilities plugin selected Log4J implementation";
+        if (LoggingModuleIdentifiers.LOG4J_OVER_SLF4J.matches(dependency)) {
+            selectCapabilityConflict(Slf4JvsLog4J2ForLog4J.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(Slf4JvsLog4J.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.LOG4J12API.matches(dependency)) {
+            selectCapabilityConflict(Slf4JvsLog4J2ForLog4J.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.LOG4J.matches(dependency)) {
+            selectCapabilityConflict(Slf4JvsLog4J2ForLog4J.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.SLF4J_LOG4J12.matches(dependency)) {
+            selectCapabilityConflict(Slf4JvsLog4J.CAPABILITY_ID, dependency, because);
+        } else {
+            throw new IllegalArgumentException("Provided dependency '" + dependency + "' is not a valid Log4J implementation");
+        }
+    }
+
+    /**
+     * Selects the provided module as the Log4J 1.2 implementation to use for the resolution of the given configuration.
+     * <p>
+     * This also resolves all other potential conflicts with the passed in module in favor of it.
+     *
+     * @param configurationName  the configuration to be setup
+     * @param dependencyNotation the Log4J 1.2 implementation module as a dependency or {@code group:name:version} notation
+     */
+    public void selectLog4J12Implementation(String configurationName, Object dependencyNotation) {
+        ExternalDependency dependency = validateNotation(dependencyNotation);
+        String because = "Logging capabilities plugin selected Log4J implementation";
+        if (LoggingModuleIdentifiers.LOG4J_OVER_SLF4J.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Slf4JvsLog4J2ForLog4J.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(configurationName, Slf4JvsLog4J.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.LOG4J12API.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Slf4JvsLog4J2ForLog4J.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.LOG4J.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Slf4JvsLog4J2ForLog4J.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.SLF4J_LOG4J12.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Slf4JvsLog4J.CAPABILITY_ID, dependency, because);
+        } else {
+            throw new IllegalArgumentException("Provided dependency '" + dependency + "' is not a valid Log4J implementation");
+        }
+    }
+
+    /**
+     * Selects the provided module as the java util logging delegation to use.
+     * <p>
+     * This also resolves all other potential conflicts with the passed in module in favor of it.
+     *
+     * @param dependencyNotation the JUL delegation module as a dependency or {@code group:name:version} notation
+     */
+    public void selectJulDelegation(Object dependencyNotation) {
+        ExternalDependency dependency = validateNotation(dependencyNotation);
+        String because = "Logging capabilities plugin selected JUL delegation";
+        if (LoggingModuleIdentifiers.JUL_TO_SLF4J.matches(dependency)) {
+            selectCapabilityConflict(Slf4JvsLog4J2ForJUL.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(Slf4JvsJUL.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.SLF4J_JDK14.matches(dependency)) {
+            selectCapabilityConflict(Slf4JvsJUL.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.LOG4J_JUL.matches(dependency)) {
+            selectCapabilityConflict(Slf4JvsLog4J2ForJUL.CAPABILITY_ID, dependency, because);
+        } else {
+            throw new IllegalArgumentException("Provided dependency '" + dependency + "' is not a valid JUL delegation");
+        }
+    }
+
+    /**
+     * Selects the provided module as the java util logging delegation to use for the resolution of the given configuration.
+     * <p>
+     * This also resolves all other potential conflicts with the passed in module in favor of it.
+     *
+     * @param configurationName  the configuration to be setup
+     * @param dependencyNotation the JUL delegation module as a dependency or {@code group:name:version} notation
+     */
+    public void selectJulDelegation(String configurationName, Object dependencyNotation) {
+        ExternalDependency dependency = validateNotation(dependencyNotation);
+        String because = "Logging capabilities plugin selected JUL delegation";
+        if (LoggingModuleIdentifiers.JUL_TO_SLF4J.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Slf4JvsLog4J2ForJUL.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(configurationName, Slf4JvsJUL.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.SLF4J_JDK14.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Slf4JvsJUL.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.LOG4J_JUL.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Slf4JvsLog4J2ForJUL.CAPABILITY_ID, dependency, because);
+        } else {
+            throw new IllegalArgumentException("Provided dependency '" + dependency + "' is not a valid JUL delegation");
+        }
+    }
+
+    /**
+     * Selects the provided module as the commons-logging implementation to use.
+     * <p>
+     * This also resolves all other potential conflicts with the passed in module in favor of it.
+     *
+     * @param dependencyNotation the commons-logging implementation module as a dependency or {@code group:name:version} notation
+     */
+    public void selectJCLImplementation(Object dependencyNotation) {
+        ExternalDependency dependency = validateNotation(dependencyNotation);
+        String because = "Logging capabilities plugin selected JCL implementation";
+        if (LoggingModuleIdentifiers.JCL_OVER_SLF4J.matches(dependency)) {
+            selectCapabilityConflict(CommonsLoggingImplementationRule.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(Slf4JVsJCL.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(Slf4JVsLog4J2ForJCL.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.COMMONS_LOGGING.matches(dependency)) {
+            selectCapabilityConflict(CommonsLoggingImplementationRule.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.SLF4J_JCL.matches(dependency)) {
+            selectCapabilityConflict(Slf4JVsJCL.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.LOG4J_JCL.matches(dependency)) {
+            selectCapabilityConflict(Slf4JVsLog4J2ForJCL.CAPABILITY_ID, dependency, because);
+            ExternalDependency commonsLogging = validateNotation(LoggingModuleIdentifiers.COMMONS_LOGGING.asVersionZero());
+            selectCapabilityConflict(CommonsLoggingImplementationRule.CAPABILITY_ID, commonsLogging, because);
+        } else {
+            throw new IllegalArgumentException("Provided dependency '" + dependency + "' is not a valid JCL implementation");
+        }
+    }
+
+    /**
+     * Selects the provided module as the commons-logging implementation to use for the resolution of the given configuration.
+     * <p>
+     * This also resolves all other potential conflicts with the passed in module in favor of it.
+     *
+     * @param configurationName  the configuration to be setup
+     * @param dependencyNotation the commons-logging implementation module as a dependency or {@code group:name:version} notation
+     */
+    public void selectJCLImplementation(String configurationName, Object dependencyNotation) {
+        ExternalDependency dependency = validateNotation(dependencyNotation);
+        String because = "Logging capabilities plugin selected JCL implementation";
+        if (LoggingModuleIdentifiers.JCL_OVER_SLF4J.matches(dependency)) {
+            selectCapabilityConflict(configurationName, CommonsLoggingImplementationRule.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(configurationName, Slf4JVsJCL.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(configurationName, Slf4JVsLog4J2ForJCL.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.COMMONS_LOGGING.matches(dependency)) {
+            selectCapabilityConflict(configurationName, CommonsLoggingImplementationRule.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.SLF4J_JCL.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Slf4JVsJCL.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.LOG4J_JCL.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Slf4JVsLog4J2ForJCL.CAPABILITY_ID, dependency, because);
+            ExternalDependency commonsLogging = validateNotation(LoggingModuleIdentifiers.COMMONS_LOGGING.asVersionZero());
+            selectCapabilityConflict(configurationName, CommonsLoggingImplementationRule.CAPABILITY_ID, commonsLogging, because);
+        } else {
+            throw new IllegalArgumentException("Provided dependency '" + dependency + "' is not a valid JCL implementation");
+        }
+    }
+
+    /**
+     * Selects the provided module as the Slf4J / Log4J 2 interaction to use.
+     * <p>
+     * This also resolves all other potential conflicts with the passed in module in favor of it.
+     *
+     * @param dependencyNotation the Slf4J / Log4J 2 interaction module as a dependency or {@code group:name:version} notation
+     */
+    public void selectSlf4JLog4J2Interaction(Object dependencyNotation) {
+        ExternalDependency dependency = validateNotation(dependencyNotation);
+        String because = "Logging capabilities plugin selected Slf4J Log4J 2 interaction";
+        if (LoggingModuleIdentifiers.LOG4J_TO_SLF4J.matches(dependency)) {
+            selectCapabilityConflict(Log4J2vsSlf4J.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(Log4J2Implementation.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.LOG4J_SLF4J_IMPL.matches(dependency) || LoggingModuleIdentifiers.LOG4J_SLF4J2_IMPL.matches(dependency)) {
+            selectCapabilityConflict(Slf4JImplementation.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(Log4J2vsSlf4J.CAPABILITY_ID, dependency, because);
+        } else {
+            throw new IllegalArgumentException("Provided dependency '" + dependency + "' is not a valid Slf4J / Log4J 2 interaction");
+        }
+    }
+
+    /**
+     * Selects the provided module as the Slf4J / Log4J 2 interaction to use for the resolution of the given configuration.
+     * <p>
+     * This also resolves all other potential conflicts with the passed in module in favor of it.
+     *
+     * @param configurationName  the configuration to be setup
+     * @param dependencyNotation the Slf4J / Log4J 2 interaction module as a dependency or {@code group:name:version} notation
+     */
+    public void selectSlf4JLog4J2Interaction(String configurationName, Object dependencyNotation) {
+        ExternalDependency dependency = validateNotation(dependencyNotation);
+        String because = "Logging capabilities plugin selected Slf4J Log4J 2 interaction";
+        if (LoggingModuleIdentifiers.LOG4J_TO_SLF4J.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Log4J2vsSlf4J.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(configurationName, Log4J2Implementation.CAPABILITY_ID, dependency, because);
+        } else if (LoggingModuleIdentifiers.LOG4J_SLF4J_IMPL.matches(dependency) || LoggingModuleIdentifiers.LOG4J_SLF4J2_IMPL.matches(dependency)) {
+            selectCapabilityConflict(configurationName, Slf4JImplementation.CAPABILITY_ID, dependency, because);
+            selectCapabilityConflict(configurationName, Log4J2vsSlf4J.CAPABILITY_ID, dependency, because);
+        } else {
+            throw new IllegalArgumentException("Provided dependency '" + dependency + "' is not a valid Slf4J / Log4J 2 interaction");
+        }
+    }
+
+    /**
+     * Selects logback as the Slf4J binding and makes sure all other supported logging frameworks end up in logback as well.
+     * <p>
+     * While having logback as a dependency is required for this to work, substitution is used for enforcing other selections that could cause missed events in logback because there are no conflicts.
+     * For example, {@code commons-logging} and {@code log4j-jcl} will be substituted with {@code jcl-over-slf4j}.
+     */
+    public void enforceLogback() {
+        selectSlf4JBinding(LoggingModuleIdentifiers.LOGBACK_CLASSIC.asVersionZero());
+        enforceSlf4JImplementation();
+    }
+
+    /**
+     * Selects logback as the Slf4J binding and makes sure all other supported logging frameworks end up in logback as well for the resolution of the given configuration.
+     * <p>
+     * While having logback as a dependency is required for this to work, substitution is used for enforcing other selections that could cause missed events in logback because there are no conflicts.
+     * For example, {@code commons-logging} and {@code log4j-jcl} will be substituted with {@code jcl-over-slf4j}.
+     *
+     * @param configurationName the configuration to be setup
+     */
+    public void enforceLogback(String configurationName) {
+        selectSlf4JBinding(configurationName, LoggingModuleIdentifiers.LOGBACK_CLASSIC.asVersionZero());
+        enforceSlf4JImplementation(configurationName);
+    }
+
+    /**
+     * Selects {@code slf4j-simple} as the Slf4J binding and makes sure all other supported logging frameworks end up in it as well.
+     * <p>
+     * While having {@code slf4j-simple} as a dependency is required for this to work, substitution is used for enforcing other selections that could cause missed events in {@code slf4j-simple} because there are no conflicts.
+     * For example, {@code commons-logging} and {@code log4j-jcl} will be substituted with {@code jcl-over-slf4j}.
+     */
+    public void enforceSlf4JSimple() {
+        selectSlf4JBinding(LoggingModuleIdentifiers.SLF4J_SIMPLE.asVersionZero());
+        enforceSlf4JImplementation();
+    }
+
+    /**
+     * Selects {@code slf4j-simple} as the Slf4J binding and makes sure all other supported logging frameworks end up in it as well for the resolution of the given configuration.
+     * <p>
+     * While having {@code slf4j-simple} as a dependency is required for this to work, substitution is used for enforcing other selections that could cause missed events in {@code slf4j-simple} because there are no conflicts.
+     * For example, {@code commons-logging} and {@code log4j-jcl} will be substituted with {@code jcl-over-slf4j}.
+     *
+     * @param configurationName the configuration to be setup
+     */
+    public void enforceSlf4JSimple(String configurationName) {
+        selectSlf4JBinding(configurationName, LoggingModuleIdentifiers.SLF4J_SIMPLE.asVersionZero());
+        enforceSlf4JImplementation(configurationName);
+    }
+
+    /**
+     * Selects {@code log4j-slf4j-impl} as the Slf4J binding and makes sure all other supported logging frameworks end up in Log4J 2 as well.
+     * <p>
+     * While having {@code log4j-slf4j-impl} as a dependency is required for this to work, substitution is used for enforcing other selections that could cause missed events in Log4J 2 because there are no conflicts.
+     * For example, {@code commons-logging} and {@code log4j} will be configured to end up in Log4J 2 as well.
+     */
+    public void enforceLog4J2() {
+        selectLog4J2Implementation(LoggingModuleIdentifiers.LOG4J_CORE.asVersionZero());
+        selectSlf4JLog4J2Interaction(LoggingModuleIdentifiers.LOG4J_SLF4J_IMPL.asVersionZero());
+        selectJulDelegation(LoggingModuleIdentifiers.LOG4J_JUL.asVersionZero());
+        selectJCLImplementation(LoggingModuleIdentifiers.LOG4J_JCL.asVersionZero());
+        selectLog4J12Implementation(LoggingModuleIdentifiers.LOG4J12API.asVersionZero());
+
+    }
+
+    /**
+     * Selects {@code log4j-slf4j-impl} as the Slf4J binding and makes sure all other supported logging frameworks end up in Log4J 2 as well for the resolution of the given configuration.
+     * <p>
+     * While having {@code log4j-slf4j-impl} as a dependency is required for this to work, substitution is used for enforcing other selections that could cause missed events in Log4J 2 because there are no conflicts.
+     * For example, {@code commons-logging} and {@code log4j} will be configured to end up in Log4J 2 as well.
+     *
+     * @param configurationName the configuration to be setup
+     */
+    public void enforceLog4J2(String configurationName) {
+        selectLog4J2Implementation(configurationName, LoggingModuleIdentifiers.LOG4J_CORE.asVersionZero());
+        selectSlf4JLog4J2Interaction(configurationName, LoggingModuleIdentifiers.LOG4J_SLF4J_IMPL.asVersionZero());
+        selectJulDelegation(configurationName, LoggingModuleIdentifiers.LOG4J_JUL.asVersionZero());
+        selectJCLImplementation(configurationName, LoggingModuleIdentifiers.LOG4J_JCL.asVersionZero());
+        selectLog4J12Implementation(configurationName, LoggingModuleIdentifiers.LOG4J12API.asVersionZero());
+    }
+
+    private void enforceSlf4JImplementation() {
+        selectLog4J12Implementation(LoggingModuleIdentifiers.LOG4J_OVER_SLF4J.asVersionZero());
+        selectJulDelegation(LoggingModuleIdentifiers.JUL_TO_SLF4J.asVersionZero());
+        selectJCLImplementation(LoggingModuleIdentifiers.JCL_OVER_SLF4J.asVersionZero());
+        selectSlf4JLog4J2Interaction(LoggingModuleIdentifiers.LOG4J_TO_SLF4J.asVersionZero());
+        selectLog4J2Implementation(LoggingModuleIdentifiers.LOG4J_TO_SLF4J.asVersionZero());
+
+        configurations.all(getSlf4JEnforcementSubstitutions());
+    }
+
+    private void enforceSlf4JImplementation(String configurationName) {
+        selectLog4J12Implementation(configurationName, LoggingModuleIdentifiers.LOG4J_OVER_SLF4J.asVersionZero());
+        selectJulDelegation(configurationName, LoggingModuleIdentifiers.JUL_TO_SLF4J.asVersionZero());
+        selectJCLImplementation(configurationName, LoggingModuleIdentifiers.JCL_OVER_SLF4J.asVersionZero());
+        selectSlf4JLog4J2Interaction(configurationName, LoggingModuleIdentifiers.LOG4J_TO_SLF4J.asVersionZero());
+        selectLog4J2Implementation(configurationName, LoggingModuleIdentifiers.LOG4J_TO_SLF4J.asVersionZero());
+
+        configurations.matching(conf -> conf.getName().equals(configurationName)).all(getSlf4JEnforcementSubstitutions());
+    }
+
+    private Action<Configuration> getSlf4JEnforcementSubstitutions() {
+        return new Slf4JEnforcementSubstitutionsUsing();
+    }
+
+    private ExternalDependency validateNotation(Object dependencyNotation) {
+        Dependency dependency = dependencies.create(dependencyNotation);
+        if (dependency instanceof ExternalDependency) {
+            return (ExternalDependency) dependency;
+        } else {
+            throw new IllegalArgumentException("Provided notation '" + dependencyNotation + "' cannot be converted to an ExternalDependency");
+        }
+    }
+
+    private void selectCapabilityConflict(String configuration, String capabilityId, ExternalDependency target, String because) {
+        configurations.matching(conf -> conf.getName().equals(configuration)).all(conf -> conf.getResolutionStrategy().capabilitiesResolution(getCapabilitiesResolutionAction(capabilityId, target, because)));
+    }
+
+    private void selectCapabilityConflict(String capabilityId, ExternalDependency target, String because) {
+        configurations.all(conf -> conf.getResolutionStrategy().capabilitiesResolution(getCapabilitiesResolutionAction(capabilityId, target, because)));
+    }
+
+    private Action<CapabilitiesResolution> getCapabilitiesResolutionAction(String capabilityId, ExternalDependency target, String because) {
+        return resolution -> resolution.withCapability(capabilityId, details -> {
+            details.getCandidates().stream().filter(candidate -> {
+                ComponentIdentifier id = candidate.getId();
+                if (!(id instanceof ModuleComponentIdentifier)) {
+                    return false;
+                }
+                ModuleComponentIdentifier moduleId = (ModuleComponentIdentifier) id;
+                return moduleId.getGroup().equals(target.getGroup())
+                        && moduleId.getModule().equals(target.getName());
+            }).findFirst().ifPresent(candidate -> details.select(candidate).because(because));
+        });
+    }
+
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/LoggingCapabilitiesPlugin.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/LoggingCapabilitiesPlugin.java
@@ -20,11 +20,16 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 
+import static org.gradlex.javaecosystem.capabilities.JavaEcosystemCapabilitiesBasePlugin.basePluginNotYetRegisteredInSettings;
+
 public class LoggingCapabilitiesPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
-        project.getPlugins().apply(JavaEcosystemCapabilitiesBasePlugin.class);
+        if (basePluginNotYetRegisteredInSettings(project)) {
+            project.getPlugins().apply(JavaEcosystemCapabilitiesBasePlugin.class);
+        }
+
         DependencyHandler dependencies = project.getDependencies();
         project.getExtensions().create("loggingCapabilities", LoggingCapabilitiesExtension.class, project.getConfigurations(), dependencies);
     }

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/LoggingCapabilitiesPlugin.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/LoggingCapabilitiesPlugin.java
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-package org.gradlex.javaecosystem.capabilities.rules.logging;
+package org.gradlex.javaecosystem.capabilities;
 
-import org.gradle.api.artifacts.ComponentMetadataContext;
-import org.gradle.api.artifacts.ComponentMetadataDetails;
-import org.gradle.api.artifacts.ComponentMetadataRule;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
 
-public class Slf4JAlignment implements ComponentMetadataRule {
+public class LoggingCapabilitiesPlugin implements Plugin<Project> {
+
     @Override
-    public void execute(ComponentMetadataContext context) {
-        ComponentMetadataDetails details = context.getDetails();
-        if (details.getId().getGroup().startsWith("org.slf4j")) {
-            details.belongsTo("org.gradlex.logging.align:slf4j:" + details.getId().getVersion());
-        }
+    public void apply(Project project) {
+        project.getPlugins().apply(JavaEcosystemCapabilitiesBasePlugin.class);
+        DependencyHandler dependencies = project.getDependencies();
+        project.getExtensions().create("loggingCapabilities", LoggingCapabilitiesExtension.class, project.getConfigurations(), dependencies);
     }
 }

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/actions/Slf4JEnforcementSubstitutionsUsing.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/actions/Slf4JEnforcementSubstitutionsUsing.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright the GradleX team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradlex.javaecosystem.capabilities.actions;
+
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradlex.javaecosystem.capabilities.rules.logging.LoggingModuleIdentifiers;
+
+public class Slf4JEnforcementSubstitutionsUsing implements Action<Configuration> {
+    @Override
+    public void execute(Configuration configuration) {
+        configuration.getResolutionStrategy().dependencySubstitution(substitution -> {
+            ComponentSelector log4JOverSlf4J = substitution.module(LoggingModuleIdentifiers.LOG4J_OVER_SLF4J.asFirstVersion());
+            substitution.substitute(substitution.module(LoggingModuleIdentifiers.LOG4J.moduleId)).using(log4JOverSlf4J);
+            substitution.substitute(substitution.module(LoggingModuleIdentifiers.LOG4J12API.moduleId)).using(log4JOverSlf4J);
+
+            substitution.substitute(substitution.module(LoggingModuleIdentifiers.LOG4J_JUL.moduleId)).using(substitution.module(LoggingModuleIdentifiers.JUL_TO_SLF4J.asFirstVersion()));
+
+            ComponentSelector jclOverSlf4J = substitution.module(LoggingModuleIdentifiers.JCL_OVER_SLF4J.asFirstVersion());
+            substitution.substitute(substitution.module(LoggingModuleIdentifiers.COMMONS_LOGGING.moduleId)).using(jclOverSlf4J);
+            substitution.substitute(substitution.module(LoggingModuleIdentifiers.LOG4J_JCL.moduleId)).using(jclOverSlf4J);
+            substitution.substitute(substitution.module(LoggingModuleIdentifiers.SPRING_JCL.moduleId)).using(jclOverSlf4J);
+        });
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/componentrules/GuavaComponentRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/componentrules/GuavaComponentRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/AddAlignmentConstraintsMetadataRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/AddAlignmentConstraintsMetadataRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/AddBomDependencyMetadataRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/AddBomDependencyMetadataRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/AddCapabilityMetadataRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/AddCapabilityMetadataRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/AddDependenciesMetadataRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/AddDependenciesMetadataRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/AddFeaturesMetadataRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/AddFeaturesMetadataRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/AddTargetPlatformVariantsMetadataRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/AddTargetPlatformVariantsMetadataRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/ComponentStatusRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/ComponentStatusRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/RemoveDependenciesMetadataRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/RemoveDependenciesMetadataRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/Target.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/customrules/Target.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/AopallianceRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/AopallianceRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/AsmRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/AsmRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/BouncycastleBcmailRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/BouncycastleBcmailRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/BouncycastleBcpgRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/BouncycastleBcpgRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/BouncycastleBcpkixRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/BouncycastleBcpkixRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/BouncycastleBcprovRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/BouncycastleBcprovRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/BouncycastleBctlsRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/BouncycastleBctlsRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/BouncycastleBctspRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/BouncycastleBctspRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/BouncycastleBcutilRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/BouncycastleBcutilRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/C3p0Rule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/C3p0Rule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/CGlibRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/CGlibRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/CommonsIoRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/CommonsIoRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/Dom4jRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/Dom4jRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/FindbugsAnnotationsRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/FindbugsAnnotationsRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/GoogleCollectionsRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/GoogleCollectionsRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/GuavaListenableFutureRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/GuavaListenableFutureRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/GuavaRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/GuavaRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/HamcrestCoreRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/HamcrestCoreRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/HamcrestLibraryRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/HamcrestLibraryRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/HikariCPRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/HikariCPRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/IntellijAnnotationsRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/IntellijAnnotationsRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaActivationApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaActivationApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaActivationImplementationRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaActivationImplementationRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaAnnotationApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaAnnotationApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaJsonApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaJsonApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaMailApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaMailApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaServletApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaServletApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaWebsocketApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaWebsocketApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaWebsocketClientApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaWebsocketClientApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaWsRsApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JakartaWsRsApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaAssistRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaAssistRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxActivationApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxActivationApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxAnnotationApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxAnnotationApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxEjbApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxEjbApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxElApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxElApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxInjectApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxInjectApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxJsonApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxJsonApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxJwsApisRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxJwsApisRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxMailApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxMailApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxPersistenceApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxPersistenceApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxServletApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxServletApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxServletJspRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxServletJspRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxServletJstlRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxServletJstlRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxSoapApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxSoapApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxValidationApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxValidationApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxWebsocketApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxWebsocketApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxWsRsApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxWsRsApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxXmlBindApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxXmlBindApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxXmlWsApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JavaxXmlWsApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JcipAnnotationsRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JcipAnnotationsRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JnaPlatformRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JnaPlatformRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JtsCoreRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JtsCoreRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JtsRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JtsRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JunitRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/JunitRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/PostgresqlRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/PostgresqlRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/StaxApiRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/StaxApiRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/VelocityRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/VelocityRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/WoodstoxAslRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/WoodstoxAslRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/CommonsLoggingImplementationRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/CommonsLoggingImplementationRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 /**

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/CommonsLoggingImplementationRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/CommonsLoggingImplementationRule.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+/**
+ * Adds capability {@code dev.jacomet.logging:commons-logging-impl:1.0} to all variants.
+ */
+public class CommonsLoggingImplementationRule extends FixedCapabilityRule {
+    public static final String CAPABILITY_NAME = "commons-logging-impl";
+    public static final String CAPABILITY_ID = CAPABILITY_GROUP + ":" + CAPABILITY_NAME;
+
+    public static final String[] MODULES = {
+
+    };
+
+    public CommonsLoggingImplementationRule() {
+        super(CAPABILITY_NAME);
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/FixedCapabilityRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/FixedCapabilityRule.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ComponentMetadataRule;
+
+/**
+ * Abstract rule adding a capability with a hard coded version.
+ */
+abstract class FixedCapabilityRule implements ComponentMetadataRule {
+    static final String CAPABILITY_GROUP = "org.gradlex.logging";
+    
+    private final String name;
+
+    protected FixedCapabilityRule(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void execute(ComponentMetadataContext context) {
+        context.getDetails().allVariants(variant -> {
+            variant.withCapabilities(capabilities -> {
+                capabilities.addCapability(CAPABILITY_GROUP, name, "1.0");
+            });
+        });
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/FixedCapabilityRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/FixedCapabilityRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 import org.gradle.api.artifacts.ComponentMetadataContext;

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Log4J2Alignment.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Log4J2Alignment.java
@@ -1,0 +1,15 @@
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ComponentMetadataDetails;
+import org.gradle.api.artifacts.ComponentMetadataRule;
+
+public class Log4J2Alignment implements ComponentMetadataRule {
+    @Override
+    public void execute(ComponentMetadataContext context) {
+        ComponentMetadataDetails details = context.getDetails();
+        if (details.getId().getGroup().startsWith("org.apache.logging.log4j")) {
+            details.belongsTo("org.apache.logging.log4j:log4j-bom:" + details.getId().getVersion(), false);
+        }
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Log4J2Alignment.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Log4J2Alignment.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright the GradleX team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 import org.gradle.api.artifacts.ComponentMetadataContext;

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Log4J2Implementation.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Log4J2Implementation.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright the GradleX team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 public class Log4J2Implementation extends VersionedCapabilityRule {

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Log4J2Implementation.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Log4J2Implementation.java
@@ -1,0 +1,11 @@
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+public class Log4J2Implementation extends VersionedCapabilityRule {
+
+    public static final String CAPABILITY_NAME = "log4j2-impl";
+    public static final String CAPABILITY_ID = FixedCapabilityRule.CAPABILITY_GROUP + ":" + CAPABILITY_NAME;
+
+    public Log4J2Implementation() {
+        super(CAPABILITY_NAME);
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Log4J2vsSlf4J.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Log4J2vsSlf4J.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 /**

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Log4J2vsSlf4J.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Log4J2vsSlf4J.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+/**
+ * Adds capability {@code dev.jacomet.logging:log4j2-vs-slf4j:<version>} to all variants, using the version of the module targeted.
+ */
+public class Log4J2vsSlf4J extends VersionedCapabilityRule {
+    public static final String CAPABILITY_NAME = "log4j2-vs-slf4j";
+    public static final String CAPABILITY_ID = FixedCapabilityRule.CAPABILITY_GROUP + ":" + CAPABILITY_NAME;
+
+    public Log4J2vsSlf4J() {
+        super(CAPABILITY_NAME);
+    }
+
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/LoggingModuleIdentifiers.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/LoggingModuleIdentifiers.java
@@ -1,0 +1,48 @@
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+import org.gradle.api.artifacts.Dependency;
+
+public enum LoggingModuleIdentifiers {
+    LOG4J_SLF4J_IMPL("org.apache.logging.log4j", "log4j-slf4j-impl", "2.0"),
+    LOG4J_SLF4J2_IMPL("org.apache.logging.log4j", "log4j-slf4j2-impl", "2.19.0"),
+    LOG4J_TO_SLF4J("org.apache.logging.log4j", "log4j-to-slf4j", "2.0"),
+    SLF4J_SIMPLE("org.slf4j", "slf4j-simple", "1.0"),
+    LOGBACK_CLASSIC("ch.qos.logback", "logback-classic", "1.0.0"),
+    SLF4J_LOG4J12("org.slf4j", "slf4j-log4j12", "1.0"),
+    SLF4J_JCL("org.slf4j", "slf4j-jcl", "1.0"),
+    SLF4J_JDK14("org.slf4j", "slf4j-jdk14", "1.0"),
+    LOG4J_OVER_SLF4J("org.slf4j", "log4j-over-slf4j", "1.4.2"),
+    LOG4J12API("org.apache.logging.log4j", "log4j-1.2-api", "2.0"),
+    LOG4J("log4j", "log4j", "1.1.3"),
+    JUL_TO_SLF4J("org.slf4j", "jul-to-slf4j", "1.5.10"),
+    LOG4J_JUL("org.apache.logging.log4j", "log4j-jul", "2.1"),
+    COMMONS_LOGGING("commons-logging", "commons-logging", "1.0"),
+    JCL_OVER_SLF4J("org.slf4j", "jcl-over-slf4j", "1.5.10"),
+    LOG4J_JCL("org.apache.logging.log4j", "log4j-jcl", "2.0"),
+    LOG4J_CORE("org.apache.logging.log4j", "log4j-core", "2.0"),
+    SPRING_JCL("org.springframework", "spring-jcl", "5.0.0.RELEASE");
+
+    public final String moduleId;
+    public final String group;
+    public final String name;
+    private final String firstVersion;
+
+    LoggingModuleIdentifiers(String group, String name, String firstVersion) {
+        this.group = group;
+        this.name = name;
+        this.firstVersion = firstVersion;
+        this.moduleId = group + ":" + name;
+    }
+
+    public boolean matches(Dependency dependency) {
+        return group.equals(dependency.getGroup()) && name.equals(dependency.getName());
+    }
+
+    public String asFirstVersion() {
+        return moduleId + ":" + firstVersion;
+    }
+
+    public String asVersionZero() {
+        return moduleId + ":0";
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/LoggingModuleIdentifiers.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/LoggingModuleIdentifiers.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright the GradleX team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 import org.gradle.api.artifacts.Dependency;

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JAlignment.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JAlignment.java
@@ -1,0 +1,15 @@
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ComponentMetadataDetails;
+import org.gradle.api.artifacts.ComponentMetadataRule;
+
+public class Slf4JAlignment implements ComponentMetadataRule {
+    @Override
+    public void execute(ComponentMetadataContext context) {
+        ComponentMetadataDetails details = context.getDetails();
+        if (details.getId().getGroup().startsWith("org.slf4j")) {
+            details.belongsTo("dev.jacomet.logging.align:slf4j:" + details.getId().getVersion());
+        }
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JAlignment.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JAlignment.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright the GradleX team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 import org.gradle.api.artifacts.ComponentMetadataContext;

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JImplementation.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JImplementation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 /**

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JImplementation.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JImplementation.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+/**
+ * Adds capability {@code dev.jacomet.logging:slf4j-impl:1.0} to all variants.
+ */
+public class Slf4JImplementation extends FixedCapabilityRule {
+
+    public static final String CAPABILITY_NAME = "slf4j-impl";
+    public static final String CAPABILITY_ID = CAPABILITY_GROUP + ":" + CAPABILITY_NAME;
+
+    public Slf4JImplementation() {
+        super(CAPABILITY_NAME);
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JVsJCL.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JVsJCL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 /**

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JVsJCL.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JVsJCL.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+/**
+ * Adds capability {@code dev.jacomet.logging:slf4j-vs-jcl:<version>} to all variants, using the version of the module targeted.
+ */
+public class Slf4JVsJCL extends VersionedCapabilityRule {
+    public static final String CAPABILITY_NAME = "slf4j-vs-jcl";
+    public static final String CAPABILITY_ID = FixedCapabilityRule.CAPABILITY_GROUP + ":" + CAPABILITY_NAME;
+
+    public Slf4JVsJCL() {
+        super(CAPABILITY_NAME);
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JVsLog4J2ForJCL.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JVsLog4J2ForJCL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 /**

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JVsLog4J2ForJCL.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JVsLog4J2ForJCL.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+/**
+ * Adds capability {@code dev.jacomet.logging:slf4j-vs-log4j2-jcl:1.0} to all variants.
+ */
+public class Slf4JVsLog4J2ForJCL extends FixedCapabilityRule {
+    public static final String CAPABILITY_NAME = "slf4j-vs-log4j2-jcl";
+    public static final String CAPABILITY_ID = CAPABILITY_GROUP + ":" + CAPABILITY_NAME;
+
+    public Slf4JVsLog4J2ForJCL() {
+        super(CAPABILITY_NAME);
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsJUL.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsJUL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 /**

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsJUL.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsJUL.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+/**
+ * Adds capability {@code dev.jacomet.logging:slf4j-vs-jul:<version>} to all variants, using the version of the module targeted.
+ */
+public class Slf4JvsJUL extends VersionedCapabilityRule {
+    public static final String CAPABILITY_NAME = "slf4j-vs-jul";
+    public static final String CAPABILITY_ID = FixedCapabilityRule.CAPABILITY_GROUP + ":" + CAPABILITY_NAME;
+
+    public Slf4JvsJUL() {
+        super(CAPABILITY_NAME);
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsLog4J.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsLog4J.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 /**

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsLog4J.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsLog4J.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+/**
+ * Adds capability {@code dev.jacomet.logging:slf4j-vs-log4j:<version>} to all variants, using the version of the module targeted.
+ */
+public class Slf4JvsLog4J extends VersionedCapabilityRule {
+    public static final String CAPABILITY_NAME = "slf4j-vs-log4j";
+    public static final String CAPABILITY_ID = FixedCapabilityRule.CAPABILITY_GROUP + ":" + CAPABILITY_NAME;
+
+    public  Slf4JvsLog4J() {
+        super(CAPABILITY_NAME);
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsLog4J2ForJUL.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsLog4J2ForJUL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 /**

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsLog4J2ForJUL.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsLog4J2ForJUL.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+/**
+ * Adds capability {@code dev.jacomet.logging:slf4j-vs-log4j2-jul:1.0} to all variants.
+ */
+public class Slf4JvsLog4J2ForJUL extends FixedCapabilityRule {
+    public static final String CAPABILITY_NAME = "slf4j-vs-log4j2-jul";
+    public static final String CAPABILITY_ID = CAPABILITY_GROUP + ":" + CAPABILITY_NAME;
+
+    public Slf4JvsLog4J2ForJUL() {
+        super(CAPABILITY_NAME);
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsLog4J2ForLog4J.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsLog4J2ForLog4J.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 /**

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsLog4J2ForLog4J.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/Slf4JvsLog4J2ForLog4J.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+/**
+ * Adds capability {@code dev.jacomet.logging:slf4j-vs-log4j2-log4j:1.0} to all variants.
+ */
+public class Slf4JvsLog4J2ForLog4J extends FixedCapabilityRule {
+    public static final String CAPABILITY_NAME = "slf4j-vs-log4j2-log4j";
+    public static final String CAPABILITY_ID = CAPABILITY_GROUP + ":" + CAPABILITY_NAME;
+
+    public Slf4JvsLog4J2ForLog4J() {
+        super(CAPABILITY_NAME);
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/VersionedCapabilityRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/VersionedCapabilityRule.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradlex.javaecosystem.capabilities.rules.logging;
+
+import org.gradle.api.artifacts.ComponentMetadataContext;
+import org.gradle.api.artifacts.ComponentMetadataDetails;
+import org.gradle.api.artifacts.ComponentMetadataRule;
+
+import static org.gradlex.javaecosystem.capabilities.rules.logging.FixedCapabilityRule.CAPABILITY_GROUP;
+
+/**
+ * Abstract rule adding a capability using the version of the module targeted.
+ */
+abstract class VersionedCapabilityRule implements ComponentMetadataRule {
+    private final String name;
+
+    public VersionedCapabilityRule(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void execute(ComponentMetadataContext context) {
+        ComponentMetadataDetails details = context.getDetails();
+        String version = details.getId().getVersion();
+        details.allVariants( variant -> {
+            variant.withCapabilities(capabilities -> {
+                capabilities.addCapability(CAPABILITY_GROUP, name, version);
+            });
+        });
+    }
+}

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/VersionedCapabilityRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/rules/logging/VersionedCapabilityRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradlex.javaecosystem.capabilities.rules.logging;
 
 import org.gradle.api.artifacts.ComponentMetadataContext;

--- a/src/main/java/org/gradlex/javaecosystem/capabilities/util/VersionNumber.java
+++ b/src/main/java/org/gradlex/javaecosystem/capabilities/util/VersionNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/CustomRulesTest.groovy
+++ b/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/CustomRulesTest.groovy
@@ -199,6 +199,9 @@ compileClasspath - Compile classpath for source set 'main'.
 |    +--- commons-io:commons-io:2.15.0
 |    +--- com.zaxxer:SparseBitSet:1.3
 |    +--- org.apache.logging.log4j:log4j-api:2.21.1
+|    |    \\--- org.apache.logging.log4j:log4j-bom:2.21.1
+|    |         +--- org.apache.logging.log4j:log4j-bom:2.21.1 (*)
+|    |         \\--- org.apache.logging.log4j:log4j-api:2.21.1 (c)
 |    +--- org.apache.poi:poi:5.2.5 (c)
 |    +--- org.apache.poi:poi-excelant:5.2.5 (c)
 |    +--- org.apache.poi:poi-ooxml:5.2.5 (c)
@@ -210,12 +213,12 @@ compileClasspath - Compile classpath for source set 'main'.
 |    |    +--- org.apache.poi:poi:5.2.5 (*)
 |    |    +--- org.apache.poi:poi-ooxml-lite:5.2.5
 |    |    |    \\--- org.apache.xmlbeans:xmlbeans:5.2.0
-|    |    |         \\--- org.apache.logging.log4j:log4j-api:2.21.1
+|    |    |         \\--- org.apache.logging.log4j:log4j-api:2.21.1 (*)
 |    |    +--- org.apache.xmlbeans:xmlbeans:5.2.0 (*)
 |    |    +--- org.apache.commons:commons-compress:1.25.0
 |    |    +--- commons-io:commons-io:2.15.0
 |    |    +--- com.github.virtuald:curvesapi:1.08
-|    |    +--- org.apache.logging.log4j:log4j-api:2.21.1
+|    |    +--- org.apache.logging.log4j:log4j-api:2.21.1 (*)
 |    |    +--- org.apache.commons:commons-collections4:4.4
 |    |    +--- org.apache.poi:poi:5.2.5 (c)
 |    |    +--- org.apache.poi:poi-excelant:5.2.5 (c)
@@ -228,7 +231,7 @@ compileClasspath - Compile classpath for source set 'main'.
 +--- org.apache.poi:poi-ooxml -> 5.2.5 (*)
 \\--- org.apache.poi:poi-scratchpad -> 5.2.5
      +--- org.apache.poi:poi:5.2.5 (*)
-     +--- org.apache.logging.log4j:log4j-api:2.21.1
+     +--- org.apache.logging.log4j:log4j-api:2.21.1 (*)
      +--- org.apache.commons:commons-math3:3.6.1
      +--- commons-codec:commons-codec:1.16.0
      +--- org.apache.poi:poi:5.2.5 (c)

--- a/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/SettingsTest.groovy
+++ b/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/SettingsTest.groovy
@@ -14,7 +14,7 @@ class SettingsTest extends Specification {
         given:
         settingsFile << """
             plugins {
-                id("org.gradlex.java-ecosystem-capabilities")
+                id("org.gradlex.java-ecosystem-capabilities-base")
             }
         """
         buildFile << """

--- a/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/logging/AbstractLoggingCapabilitiesPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/logging/AbstractLoggingCapabilitiesPluginFunctionalTest.groovy
@@ -1,0 +1,72 @@
+package org.gradlex.javaecosystem.capabilities.test.logging
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.util.GradleVersion
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Path
+
+abstract class AbstractLoggingCapabilitiesPluginFunctionalTest extends Specification {
+
+    static GradleVersion testGradleVersion = System.getProperty("test.gradle-version")?.with { GradleVersion.version(it) } ?: GradleVersion.current()
+
+    @TempDir
+    Path testFolder
+    File buildFile
+
+    def setup() {
+        buildFile = testFolder.resolve('build.gradle.kts').toFile()
+        testFolder.resolve('settings.gradle.kts').toFile() << 'rootProject.name = "test-project"'
+    }
+
+    TaskOutcome outcomeOf(BuildResult result, String path) {
+        result.task(path)?.outcome
+    }
+
+    BuildResult build(List<String> args) {
+        gradleRunnerFor(args).build()
+    }
+
+    BuildResult buildAndFail(List<String> args) {
+        gradleRunnerFor(args).buildAndFail()
+    }
+
+    GradleRunner gradleRunnerFor(List<String>  args) {
+        GradleRunner.create()
+                .forwardOutput()
+                .withGradleVersion(testGradleVersion.version)
+                .withPluginClasspath()
+                .withProjectDir(testFolder.toFile())
+                .withArguments(args + ["-s"])
+    }
+
+    void withBuildScript(String content) {
+        buildFile << content
+    }
+
+    void withBuildScriptWithDependencies(String... dependencies) {
+        buildFile << """
+            plugins {
+                `java-library`
+                id("org.gradlex.java-ecosystem-capabilities")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+${dependencies.collect { "                implementation(\"$it\")" }.join("\n")}
+            }
+
+            tasks.register("doIt") {
+                doLast {
+                    println(configurations["compileClasspath"].files)
+                }
+            }
+        """
+    }
+}

--- a/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/logging/AbstractLoggingCapabilitiesPluginFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/logging/AbstractLoggingCapabilitiesPluginFunctionalTest.groovy
@@ -51,7 +51,7 @@ abstract class AbstractLoggingCapabilitiesPluginFunctionalTest extends Specifica
         buildFile << """
             plugins {
                 `java-library`
-                id("org.gradlex.java-ecosystem-capabilities")
+                id("org.gradlex.logging-capabilities")
             }
 
             repositories {

--- a/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/logging/LoggingCapabilitiesPluginDetectionFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/logging/LoggingCapabilitiesPluginDetectionFunctionalTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradlex.javaecosystem.capabilities.test.logging
 
 import org.gradle.util.GradleVersion

--- a/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/logging/LoggingCapabilitiesPluginDetectionFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/logging/LoggingCapabilitiesPluginDetectionFunctionalTest.groovy
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradlex.javaecosystem.capabilities.test.logging
+
+import org.gradle.util.GradleVersion
+import spock.lang.Requires
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.FAILED
+
+class LoggingCapabilitiesPluginDetectionFunctionalTest extends AbstractLoggingCapabilitiesPluginFunctionalTest {
+
+    boolean conflictOnCapability(String output, String capability) {
+        // Error became lenient in Gradle 5.3, with a different error message:
+        // https://github.com/gradle/gradle/commit/0c10062f9c86192b2568b0035ec8885c75b024cc
+        return output.contains("conflict on capability '$capability'") || // Gradle >= 5.3
+               output.contains("provide the same capability: $capability") // Gradle <= 5.2
+    }
+
+    @Unroll
+    def "can detect Slf4J logger implementation conflicts with #first and #second"() {
+        given:
+        withBuildScriptWithDependencies(first, second)
+
+        when:
+        def result = buildAndFail(['doIt'])
+
+        then:
+        outcomeOf(result, ':doIt') == FAILED
+        conflictOnCapability(result.output, "org.gradlex.logging:slf4j-impl:1.0")
+
+        where:
+        first                           | second
+        'org.slf4j:slf4j-simple:1.7.27' | 'ch.qos.logback:logback-classic:1.2.3'
+        'org.slf4j:slf4j-simple:1.7.27' | 'org.slf4j:slf4j-log4j12:1.7.27'
+        'org.slf4j:slf4j-simple:1.7.27' | 'org.slf4j:slf4j-jcl:1.7.27'
+        'org.slf4j:slf4j-simple:1.7.27' | 'org.slf4j:slf4j-jdk14:1.7.27'
+        'org.slf4j:slf4j-simple:1.7.27' | 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
+        'org.slf4j:slf4j-simple:1.7.27' | 'org.apache.logging.log4j:log4j-slf4j2-impl:2.20.0'
+
+    }
+
+    @Unroll
+    def "can detect Slf4J logger implementation / bridge implementation conflicts with #first and #second"() {
+        given:
+        withBuildScriptWithDependencies(first, second)
+
+        when:
+        def result = buildAndFail(['doIt'])
+
+        then:
+        outcomeOf(result, ':doIt') == FAILED
+        conflictOnCapability(result.output, "org.gradlex.logging:$capability:1.7.27")
+
+        where:
+        first                               | second                            | capability
+        'org.slf4j:jcl-over-slf4j:1.7.27'   | 'org.slf4j:slf4j-jcl:1.7.27'      | 'slf4j-vs-jcl'
+        'org.slf4j:jul-to-slf4j:1.7.27'     | 'org.slf4j:slf4j-jdk14:1.7.27'    | 'slf4j-vs-jul'
+        'org.slf4j:log4j-over-slf4j:1.7.27' | 'org.slf4j:slf4j-log4j12:1.7.27'  | 'slf4j-vs-log4j'
+    }
+
+    @Unroll
+    def "can detect Slf4J bridge implementations vs native logger implementations with #first and #second"() {
+        given:
+        withBuildScriptWithDependencies(first, second)
+
+        when:
+        def result = buildAndFail(['doIt'])
+
+        then:
+        outcomeOf(result, ':doIt') == FAILED
+        conflictOnCapability(result.output, "org.gradlex.logging:$capability:1.0")
+
+        where:
+        first                                           | second                                            | capability
+        'org.slf4j:jcl-over-slf4j:1.7.27'               | 'commons-logging:commons-logging:1.2'             | 'commons-logging-impl'
+        'org.springframework:spring-jcl:5.3.9'          | 'commons-logging:commons-logging:1.2'             | 'commons-logging-impl'
+        'org.slf4j:log4j-over-slf4j:1.7.27'             | 'log4j:log4j:1.2.9'                               | 'slf4j-vs-log4j2-log4j'
+        'org.slf4j:log4j-over-slf4j:1.7.27'             | 'org.apache.logging.log4j:log4j-1.2-api:2.17.0'   | 'slf4j-vs-log4j2-log4j'
+        'org.slf4j:slf4j-log4j12:1.7.27'                | 'org.apache.logging.log4j:log4j-1.2-api:2.17.0'   | 'slf4j-vs-log4j2-log4j'
+        'org.apache.logging.log4j:log4j-1.2-api:2.17.0' | 'org.slf4j:slf4j-log4j12:1.7.27'                  | 'slf4j-vs-log4j2-log4j'
+    }
+
+    @Unroll
+    def "can detect Log4J2 logger implementation / bridge implementation conflict with #bridge"() {
+        given:
+        withBuildScriptWithDependencies(bridge, 'org.apache.logging.log4j:log4j-to-slf4j:2.20.0')
+
+        when:
+        def result = buildAndFail(['doIt'])
+
+        then:
+        outcomeOf(result, ':doIt') == FAILED
+        conflictOnCapability(result.output, "org.gradlex.logging:log4j2-vs-slf4j:2.20.0")
+
+        where:
+        bridge << ['org.apache.logging.log4j:log4j-slf4j-impl:2.20.0', 'org.apache.logging.log4j:log4j-slf4j2-impl:2.20.0']
+    }
+
+    def "can detect Log4J2 logger implementation conflict"() {
+        given:
+        withBuildScriptWithDependencies('org.apache.logging.log4j:log4j-core:2.17.0', 'org.apache.logging.log4j:log4j-to-slf4j:2.17.0')
+
+        when:
+        def result = buildAndFail(['doIt'])
+
+        then:
+        outcomeOf(result, ':doIt') == FAILED
+        conflictOnCapability(result.output, "org.gradlex.logging:log4j2-impl:2.17.0")
+    }
+
+    @Unroll
+    def "can detect conflicting bridge implementations from Slf4J and Log4J2 with #first and #second"() {
+        given:
+        withBuildScriptWithDependencies(first, second)
+
+        when:
+        def result = buildAndFail(['doIt'])
+
+        then:
+        outcomeOf(result, ':doIt') == FAILED
+        conflictOnCapability(result.output, "org.gradlex.logging:$capability:1.0")
+
+        where:
+        first                               | second                                        | capability
+        'org.slf4j:jul-to-slf4j:1.7.27'     | 'org.apache.logging.log4j:log4j-jul:2.17.0'   | 'slf4j-vs-log4j2-jul'
+        'org.slf4j:jcl-over-slf4j:1.7.27'   | 'org.apache.logging.log4j:log4j-jcl:2.17.0'   | 'slf4j-vs-log4j2-jcl'
+    }
+
+    def "provides alignment on Slf4J"() {
+        given:
+        withBuildScriptWithDependencies("org.slf4j:slf4j-simple:1.7.25", "org.slf4j:slf4j-api:1.7.27")
+
+        when:
+        def result = build(['doIt'])
+
+        then:
+        result.output.contains("slf4j-simple-1.7.27.jar")
+    }
+
+    def "provides alignment on Log4J 2"() {
+        given:
+        withBuildScriptWithDependencies("org.apache.logging.log4j:log4j-to-slf4j:2.17.0", "org.apache.logging.log4j:log4j-api:2.16.0")
+
+        when:
+        def result = build(['doIt'])
+
+        then:
+        result.output.contains("log4j-to-slf4j-2.17.0.jar")
+    }
+}

--- a/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/logging/LoggingCapabilitiesPluginSelectionFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/logging/LoggingCapabilitiesPluginSelectionFunctionalTest.groovy
@@ -1,0 +1,333 @@
+package org.gradlex.javaecosystem.capabilities.test.logging
+
+import org.gradle.util.GradleVersion
+import spock.lang.IgnoreIf
+import spock.lang.Unroll
+
+import static org.gradle.testkit.runner.TaskOutcome.FAILED
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+class LoggingCapabilitiesPluginSelectionFunctionalTest extends AbstractLoggingCapabilitiesPluginFunctionalTest {
+
+    @Unroll
+    // Looks like a regression in Gradle 6.7+: https://github.com/ljacomet/logging-capabilities/issues/20
+    @IgnoreIf({ instance.testGradleVersion >= GradleVersion.version("6.7") })
+    def "can select logback in case of conflict (with extra #additional)"() {
+        given:
+        withBuildScript("""
+            plugins {
+                `java-library`
+                id("org.gradlex.logging-capabilities")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            loggingCapabilities {
+                selectSlf4JBinding("ch.qos.logback:logback-classic:1.2.3")
+            }
+
+            dependencies {
+                runtimeOnly("org.slf4j:slf4j-simple:1.7.27")
+${additional.collect { "                runtimeOnly(\"$it\")" }.join("\n")}                
+                runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+            }
+
+            tasks.register("doIt") {
+                doLast {
+                    println(configurations["runtimeClasspath"].files)
+                }
+            }
+""")
+        when:
+        def result = build(['doIt'])
+
+        then:
+        outcomeOf(result, ':doIt') == SUCCESS
+        result.output.contains("logback-classic-1.2.3.jar")
+
+        where:
+        additional << [[], ["org.slf4j:slf4j-log4j12:1.7.27"], ["org.slf4j:slf4j-jcl:1.7.27", "org.slf4j:slf4j-log4j12:1.7.27"]]
+    }
+
+    def "fail to select logback in case of conflict but logback not available"() {
+        given:
+        withBuildScript("""
+            plugins {
+                `java-library`
+                id("org.gradlex.logging-capabilities")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+            
+            loggingCapabilities {
+                selectSlf4JBinding("ch.qos.logback:logback-classic:1.2.3")
+            }
+
+
+            dependencies {
+                runtimeOnly("org.slf4j:slf4j-simple:1.7.27")
+                runtimeOnly("org.slf4j:slf4j-log4j12:1.7.27")
+            }
+
+            tasks.register("doIt") {
+                doLast {
+                    println(configurations["runtimeClasspath"].files)
+                }
+            }
+""")
+        when:
+        def result = buildAndFail(['doIt'])
+
+        then:
+        outcomeOf(result, ':doIt') == FAILED
+        result.output.contains("conflict on capability 'org.gradlex.logging:slf4j-impl:1.0'")
+    }
+
+    @Unroll
+    def "configuring logger leaves no open conflicts (using #prefered)"() {
+        given:
+        withBuildScript("""
+            plugins {
+                `java-library`
+                id("org.gradlex.logging-capabilities")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+            
+            loggingCapabilities {
+                $prefered
+            }
+            
+            dependencies {
+                implementation("org.slf4j:slf4j-api:1.7.27")
+                implementation("org.apache.logging.log4j:log4j-api:2.12.1")
+                
+                implementation("log4j:log4j:1.2.17")
+                implementation("commons-logging:commons-logging:1.2")
+                
+                runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.12.1")
+                runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+                runtimeOnly("org.slf4j:slf4j-simple:1.7.27")
+                runtimeOnly("org.slf4j:slf4j-log4j12:1.7.27")
+                runtimeOnly("org.slf4j:log4j-over-slf4j:1.7.27")
+                runtimeOnly("org.slf4j:jul-to-slf4j:1.7.27")
+                runtimeOnly("org.slf4j:slf4j-jdk14:1.7.27")
+                runtimeOnly("org.slf4j:slf4j-jcl:1.7.27")
+                runtimeOnly("org.slf4j:jcl-over-slf4j:1.7.27")
+
+                runtimeOnly("org.apache.logging.log4j:log4j-jul:2.12.1")
+                runtimeOnly("org.apache.logging.log4j:log4j-1.2-api:2.12.1")
+                runtimeOnly("org.apache.logging.log4j:log4j-to-slf4j:2.12.1")
+                runtimeOnly("org.apache.logging.log4j:log4j-jcl:2.12.1")
+            }
+
+            tasks.register("doIt") {
+                doLast {
+                    println(configurations["runtimeClasspath"].files)
+                }
+            }
+""")
+        when:
+        def result = build(['doIt'])
+
+        then:
+        outcomeOf(result, ':doIt') == SUCCESS
+        result.output.contains(selected)
+
+        where:
+        prefered               | selected
+        "enforceLogback()"     | "logback-classic-1.2.3.jar"
+        "enforceSlf4JSimple()" | "slf4j-simple-1.7.27.jar"
+        "enforceLog4J2()"      | "log4j-slf4j-impl-2.12.1.jar"
+    }
+
+    @Unroll
+    def "Enforcing a logger leaves no open conflict when enforcing #enforced and #extra is present"() {
+        given:
+        withBuildScript("""
+            plugins {
+                `java-library`
+                id("org.gradlex.logging-capabilities")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+            
+            loggingCapabilities {
+                ${loggerFrom(enforced)}
+            }
+
+            dependencies {
+                runtimeOnly("$enforced")
+                runtimeOnly("$extra")
+            }
+
+            tasks.register("doIt") {
+                doLast {
+                    println(configurations["runtimeClasspath"].files)
+                }
+            }
+""")
+        when:
+        def result = build(['doIt'])
+
+        then:
+        outcomeOf(result, ':doIt') == SUCCESS
+
+        where:
+        [enforced, extra] << [["ch.qos.logback:logback-classic:1.2.3", "org.slf4j:slf4j-simple:1.7.27", "org.apache.logging.log4j:log4j-slf4j-impl:2.12.1"],
+                               ["log4j:log4j:1.2.17", "commons-logging:commons-logging:1.2", "org.apache.logging.log4j:log4j-slf4j-impl:2.12.1", "ch.qos.logback:logback-classic:1.2.3",
+                                "org.slf4j:slf4j-simple:1.7.27", "org.slf4j:slf4j-log4j12:1.7.27", "org.slf4j:log4j-over-slf4j:1.7.27", "org.slf4j:jul-to-slf4j:1.7.27", "org.slf4j:slf4j-jdk14:1.7.27",
+                                "org.slf4j:slf4j-jcl:1.7.27", "org.slf4j:jcl-over-slf4j:1.7.27", "org.apache.logging.log4j:log4j-jul:2.12.1", "org.apache.logging.log4j:log4j-1.2-api:2.12.1",
+                                "org.apache.logging.log4j:log4j-to-slf4j:2.12.1", "org.apache.logging.log4j:log4j-jcl:2.12.1", "org.apache.logging.log4j:log4j-core:2.12.1"]].combinations()
+    }
+
+    String loggerFrom(String enforced) {
+        if (enforced.contains('logback-classic')) {
+            return 'enforceLogback()'
+        } else if (enforced.contains('slf4j-simple')) {
+            return 'enforceSlf4JSimple()'
+        } else if (enforced.contains('log4j-slf4j-impl')) {
+            return 'enforceLog4J2()'
+        }
+        throw new IllegalArgumentException("Unexpected value: $enforced")
+    }
+
+
+    def "can enforce logback and commons-logging is substituted"() {
+        withBuildScript("""
+            plugins {
+                `java-library`
+                id("org.gradlex.logging-capabilities")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+            
+            loggingCapabilities {
+                enforceLogback()
+            }
+            
+            dependencies {
+                implementation("org.slf4j:slf4j-api:1.7.27")
+                
+                implementation("commons-logging:commons-logging:1.2")
+                
+                runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+            }
+
+            tasks.register("doIt") {
+                doLast {
+                    println(configurations["runtimeClasspath"].files)
+                }
+            }
+""")
+        when:
+        def result = build(['doIt'])
+
+        then:
+        outcomeOf(result, ':doIt') == SUCCESS
+        !result.output.contains("commons-logging-1.2.jar")
+        result.output.contains("jcl-over-slf4j-1.7.27.jar")
+    }
+
+    def "can enforce logback and spring-jcl is substituted"() {
+        withBuildScript("""
+            plugins {
+                `java-library`
+                id("org.gradlex.logging-capabilities")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            loggingCapabilities {
+                enforceLogback()
+            }
+
+            dependencies {
+                implementation("org.slf4j:slf4j-api:1.7.27")
+
+                implementation("org.springframework:spring-jcl:5.3.9")
+
+                runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+            }
+
+            tasks.register("doIt") {
+                doLast {
+                    println(configurations["runtimeClasspath"].files)
+                }
+            }
+""")
+        when:
+        def result = build(['doIt'])
+
+        then:
+        outcomeOf(result, ':doIt') == SUCCESS
+        !result.output.contains("spring-jcl-5.3.9.jar")
+        result.output.contains("jcl-over-slf4j-1.7.27.jar")
+    }
+
+    def "can enforce different loggers in runtime and test"() {
+        given:
+        withBuildScript("""
+            plugins {
+                `java-library`
+                id("org.gradlex.logging-capabilities")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+            
+            loggingCapabilities {
+                enforceLog4J2("runtimeClasspath")
+                enforceSlf4JSimple("testRuntimeClasspath")
+            }
+            
+            dependencies {
+                implementation("org.slf4j:slf4j-api:1.7.27")
+                implementation("org.apache.logging.log4j:log4j-api:2.12.1")
+                
+                implementation("log4j:log4j:1.2.17")
+                implementation("commons-logging:commons-logging:1.2")
+                
+                runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.12.1")
+                runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+                runtimeOnly("org.slf4j:slf4j-simple:1.7.27")
+                runtimeOnly("org.slf4j:slf4j-log4j12:1.7.27")
+                runtimeOnly("org.slf4j:log4j-over-slf4j:1.7.27")
+                runtimeOnly("org.slf4j:jul-to-slf4j:1.7.27")
+                runtimeOnly("org.slf4j:slf4j-jdk14:1.7.27")
+                runtimeOnly("org.slf4j:slf4j-jcl:1.7.27")
+                runtimeOnly("org.slf4j:jcl-over-slf4j:1.7.27")
+
+                runtimeOnly("org.apache.logging.log4j:log4j-jul:2.12.1")
+                runtimeOnly("org.apache.logging.log4j:log4j-1.2-api:2.12.1")
+                runtimeOnly("org.apache.logging.log4j:log4j-to-slf4j:2.12.1")
+                runtimeOnly("org.apache.logging.log4j:log4j-jcl:2.12.1")
+            }
+
+            tasks.register("doIt") {
+                doLast {
+                    println(configurations["runtimeClasspath"].files)
+                    println(configurations["testRuntimeClasspath"].files)
+                }
+            }
+""")
+        when:
+        def result = build(['doIt'])
+
+        then:
+        outcomeOf(result, ':doIt') == SUCCESS
+    }
+}

--- a/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/logging/LoggingCapabilitiesPluginSelectionFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javaecosystem/capabilities/test/logging/LoggingCapabilitiesPluginSelectionFunctionalTest.groovy
@@ -1,7 +1,5 @@
 package org.gradlex.javaecosystem.capabilities.test.logging
 
-import org.gradle.util.GradleVersion
-import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.FAILED
@@ -10,8 +8,6 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 class LoggingCapabilitiesPluginSelectionFunctionalTest extends AbstractLoggingCapabilitiesPluginFunctionalTest {
 
     @Unroll
-    // Looks like a regression in Gradle 6.7+: https://github.com/ljacomet/logging-capabilities/issues/20
-    @IgnoreIf({ instance.testGradleVersion >= GradleVersion.version("6.7") })
     def "can select logback in case of conflict (with extra #additional)"() {
         given:
         withBuildScript("""
@@ -29,9 +25,11 @@ class LoggingCapabilitiesPluginSelectionFunctionalTest extends AbstractLoggingCa
             }
 
             dependencies {
+                // Looks like a regression in Gradle 6.7+: https://github.com/ljacomet/logging-capabilities/issues/20
+                // Moving that declaration to be last will show the problem
+                runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
                 runtimeOnly("org.slf4j:slf4j-simple:1.7.27")
 ${additional.collect { "                runtimeOnly(\"$it\")" }.join("\n")}                
-                runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
             }
 
             tasks.register("doIt") {

--- a/src/test/java/org/gradlex/javaecosystem/capabilities/samples/PluginBuildLocationSampleModifier.java
+++ b/src/test/java/org/gradlex/javaecosystem/capabilities/samples/PluginBuildLocationSampleModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/gradlex/javaecosystem/capabilities/samples/SamplesTest.java
+++ b/src/test/java/org/gradlex/javaecosystem/capabilities/samples/SamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the GradleX team.
+ * Copyright the GradleX team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Merge code from the 'dev.jacomet.logging-capabilities' plugin into
this plugin. This also includes updating the minimal required Gradle
version to 6.6.2.

Resolves #78