### PR TITLE
Adjust alignment rule to work without 'belongsTo'

### DIFF
--- a/src/main/java/org/gradlex/javaecosystem/conflict/detection/rules/AlignmentDefinition.java
+++ b/src/main/java/org/gradlex/javaecosystem/conflict/detection/rules/AlignmentDefinition.java
@@ -84,7 +84,7 @@ public enum AlignmentDefinition {
     private final Class<? extends AlignmentDefinitionRule> ruleClass;
 
     AlignmentDefinition(Class<? extends AlignmentDefinitionRule> ruleClass, String... modules) {
-        this.bom =  "org.gradlex.align:" + name().toLowerCase().replace("_", "-");
+        this.bom = null;
         this.ruleClass = ruleClass;
         this.modules = Arrays.asList(modules);
     }
@@ -107,7 +107,7 @@ public enum AlignmentDefinition {
         return ruleClass;
     }
 
-    public boolean isVirtual() {
-        return bom.startsWith("org.gradlex.align:");
+    public boolean hasBom() {
+        return bom != null;
     }
 }

--- a/src/main/java/org/gradlex/javaecosystem/conflict/detection/rules/AlignmentDefinitionRule.java
+++ b/src/main/java/org/gradlex/javaecosystem/conflict/detection/rules/AlignmentDefinitionRule.java
@@ -21,6 +21,8 @@ import org.gradle.api.artifacts.ComponentMetadataContext;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
 import org.gradle.api.artifacts.ComponentMetadataRule;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
 
@@ -34,13 +36,41 @@ public abstract class AlignmentDefinitionRule implements ComponentMetadataRule {
         this.definition = definition;
     }
 
+    @Inject
+    protected abstract ObjectFactory getObjects();
+
     @Override
     public final void execute(ComponentMetadataContext context) {
         ComponentMetadataDetails details = context.getDetails();
         if (shouldApply(details.getId())) {
-            String version = details.getId().getVersion();
-            details.belongsTo(definition.getBom() + ":" + version, definition.isVirtual());
+            if (definition.hasBom()) {
+                applyWithBom(details);
+            } else {
+                applyWithoutBom(details);
+            }
         }
+    }
+
+    void applyWithBom(ComponentMetadataDetails details) {
+        String version = details.getId().getVersion();
+        details.allVariants(v -> v.withDependencies(dependencies -> dependencies.add(definition.getBom() + ":" + version,
+                d -> d.attributes(a -> a.attribute(Category.CATEGORY_ATTRIBUTE, getObjects().named(Category.class, Category.REGULAR_PLATFORM))))));
+    }
+
+    void applyWithoutBom(ComponentMetadataDetails details) {
+        String version = details.getId().getVersion();
+        String group = details.getId().getGroup();
+        details.allVariants(v -> {
+            v.withDependencyConstraints(c -> {
+                for (String member : definition.getModules()) {
+                    if (member.contains(":")) {
+                        c.add(member + ":" + version);
+                    } else {
+                        c.add(group + ":" + member + ":" + version);
+                    }
+                }
+            });
+        });
     }
 
     protected boolean shouldApply(ModuleVersionIdentifier id) {

--- a/src/test/groovy/org/gradlex/javaecosystem/conflict/test/logging/LoggingCapabilitiesPluginDetectionFunctionalTest.groovy
+++ b/src/test/groovy/org/gradlex/javaecosystem/conflict/test/logging/LoggingCapabilitiesPluginDetectionFunctionalTest.groovy
@@ -150,9 +150,31 @@ class LoggingCapabilitiesPluginDetectionFunctionalTest extends AbstractLoggingCa
         result.output.contains("slf4j-simple-1.7.27.jar")
     }
 
+    def "provides alignment on Slf4J for dependency without version"() {
+        given:
+        withBuildScriptWithDependencies("org.slf4j:slf4j-simple", "org.slf4j:slf4j-api:1.7.27")
+
+        when:
+        def result = build(['doIt'])
+
+        then:
+        result.output.contains("slf4j-simple-1.7.27.jar")
+    }
+
     def "provides alignment on Slf4J2"() {
         given:
         withBuildScriptWithDependencies("org.slf4j:slf4j-simple:2.0.9", "org.slf4j:slf4j-api:2.0.11")
+
+        when:
+        def result = build(['doIt'])
+
+        then:
+        result.output.contains("slf4j-simple-2.0.11.jar")
+    }
+
+    def "provides alignment on Slf4J2 for dependency without version"() {
+        given:
+        withBuildScriptWithDependencies("org.slf4j:slf4j-simple", "org.slf4j:slf4j-api:2.0.11")
 
         when:
         def result = build(['doIt'])


### PR DESCRIPTION
This has the advantage that:
- No "virtual" platforms, which means dependencies without any version are also aligned even if there is no BOM
- Exactly the same behavior as-if the alignment metadata would be published