### PR TITLE
Updated LZ4 capability

### DIFF
--- a/samples/sample-all-deactivated/build.gradle.kts
+++ b/samples/sample-all-deactivated/build.gradle.kts
@@ -245,6 +245,7 @@ dependencies {
     implementation("org.jzy3d:jzy3d-emul-gl:2.0.0")
     implementation("org.jzy3d:jzy3d-jGL-awt:2.2.1")
     implementation("org.lz4:lz4-java:1.8.0")
+    implementation("at.yawk.lz4:lz4-java:1.9.0")
     implementation("org.ow2.asm:asm:9.9")
     implementation("org.postgresql:postgresql:42.7.8")
     implementation("org.slf4j:jcl-over-slf4j:2.0.17")

--- a/samples/sample-all-deactivated/build.out
+++ b/samples/sample-all-deactivated/build.out
@@ -253,6 +253,7 @@ compileClasspath - Compile classpath for source set 'main'.
 +--- org.jzy3d:jzy3d-emul-gl:2.0.0 FAILED
 +--- org.jzy3d:jzy3d-jGL-awt:2.2.1 FAILED
 +--- org.lz4:lz4-java:1.8.0 FAILED
++--- at.yawk.lz4:lz4-java:1.9.0 FAILED
 +--- org.ow2.asm:asm:9.9 FAILED
 +--- org.postgresql:postgresql:42.7.8 FAILED
 +--- org.slf4j:jcl-over-slf4j:2.0.17 FAILED

--- a/samples/sample-all/build.gradle.kts
+++ b/samples/sample-all/build.gradle.kts
@@ -248,6 +248,7 @@ dependencies {
     implementation("org.jzy3d:jzy3d-emul-gl:2.0.0")
     implementation("org.jzy3d:jzy3d-jGL-awt:2.2.1")
     implementation("org.lz4:lz4-java:1.8.0")
+    implementation("at.yawk.lz4:lz4-java:1.9.0")
     implementation("org.ow2.asm:asm:9.9")
     implementation("org.postgresql:postgresql:42.7.8")
     implementation("org.slf4j:jcl-over-slf4j:2.0.17")

--- a/samples/sample-all/build.out
+++ b/samples/sample-all/build.out
@@ -159,7 +159,7 @@ compileClasspath - Compile classpath for source set 'main'.
 +--- net.java.dev.jna:jna:5.18.1 -> net.java.dev.jna:jna-jpms:5.18.1
 +--- net.java.dev.jna:platform:3.5.2 -> net.java.dev.jna:jna-platform-jpms:5.18.1 (*)
 +--- net.jcip:jcip-annotations:1.0
-+--- net.jpountz.lz4:lz4:1.3 -> org.lz4:lz4-java:1.8.0
++--- net.jpountz.lz4:lz4:1.3 -> at.yawk.lz4:lz4-java:1.9.0
 +--- org.apache.commons:commons-csv:1.14.1 -> org.apache.solr:solr-commons-csv:3.5.0
 |    \--- org.slf4j:slf4j-api:1.6.1 -> 2.0.17 (*)
 +--- org.apache.commons:commons-io:1.3.2 -> commons-io:commons-io:2.20.0
@@ -360,7 +360,8 @@ compileClasspath - Compile classpath for source set 'main'.
 |    \--- org.apache.logging.log4j:log4j-core:2.17.1 -> org.apache.logging.log4j:log4j-to-slf4j:2.25.2 (*)
 +--- org.jzy3d:jzy3d-emul-gl:2.0.0 -> org.jzy3d:jzy3d-emul-gl-awt:2.2.1 (*)
 +--- org.jzy3d:jzy3d-jGL-awt:2.2.1 -> org.jzy3d:jGL:2.5
-+--- org.lz4:lz4-java:1.8.0
++--- org.lz4:lz4-java:1.8.0 -> at.yawk.lz4:lz4-java:1.9.0
++--- at.yawk.lz4:lz4-java:1.9.0
 +--- org.ow2.asm:asm:9.9 (*)
 +--- org.postgresql:postgresql:42.7.8
 +--- org.slf4j:jcl-over-slf4j:2.0.17 (*)

--- a/src/main/java/org/gradlex/jvm/dependency/conflict/detection/rules/CapabilityDefinition.java
+++ b/src/main/java/org/gradlex/jvm/dependency/conflict/detection/rules/CapabilityDefinition.java
@@ -157,7 +157,7 @@ public enum CapabilityDefinition {
     GUAVA(HIGHEST_VERSION, "com.google.guava:guava", "com.google.guava:guava-jdk5"),
     JZY3D_EMUL_GL(HIGHEST_VERSION, "org.jzy3d:jzy3d-emul-gl", "org.jzy3d:jzy3d-emul-gl-awt"),
     JZY3D_JGL(HIGHEST_VERSION, "org.jzy3d:jGL", "org.jzy3d:jzy3d-jGL-awt"),
-    LZ4(HIGHEST_VERSION, "net.jpountz.lz4:lz4", "org.lz4:lz4-java"),
+    LZ4(HIGHEST_VERSION, "net.jpountz.lz4:lz4", "org.lz4:lz4-java", "at.yawk.lz4:lz4-java"),
     LISTENABLEFUTURE(
             FIRST_MODULE,
             "com.google.guava",


### PR DESCRIPTION
With the [latest version](https://central.sonatype.com/artifact/org.lz4/lz4-java) `org.lz4:lz4-java` was moved to `at.yawk.lz4:lz4-java`.